### PR TITLE
majorana rotations fixed

### DIFF
--- a/notebooks/Majorana operator.ipynb
+++ b/notebooks/Majorana operator.ipynb
@@ -436,7 +436,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 11,
    "id": "911ccf06",
    "metadata": {},
    "outputs": [
@@ -463,7 +463,7 @@
        "       [1, 1, 1, 0, 1, 1]])"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -489,7 +489,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 12,
    "id": "46ba38ea",
    "metadata": {},
    "outputs": [
@@ -536,7 +536,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 13,
    "id": "924583c8",
    "metadata": {},
    "outputs": [
@@ -551,7 +551,7 @@
        "       [1, 1, 1, 0, 1, 1]])"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -570,7 +570,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 14,
    "id": "13392b71",
    "metadata": {},
    "outputs": [
@@ -622,7 +622,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 15,
    "id": "4a6869ea",
    "metadata": {},
    "outputs": [],
@@ -637,7 +637,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "id": "c667b16d",
    "metadata": {},
    "outputs": [],
@@ -675,7 +675,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "id": "de12ecbf",
    "metadata": {},
    "outputs": [
@@ -689,7 +689,7 @@
        "       [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1]])"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -705,7 +705,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 18,
    "id": "ca5a4019",
    "metadata": {},
    "outputs": [
@@ -733,7 +733,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 19,
    "id": "2b223fc1",
    "metadata": {},
    "outputs": [
@@ -750,7 +750,7 @@
        "True"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -766,7 +766,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 20,
    "id": "3437885d",
    "metadata": {},
    "outputs": [
@@ -780,7 +780,7 @@
        "(1+0j) [Z6 Z7 Z8 Z9]"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -819,7 +819,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 21,
    "id": "b7b53d3f",
    "metadata": {},
    "outputs": [],
@@ -829,7 +829,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 22,
    "id": "89c32ee3",
    "metadata": {},
    "outputs": [
@@ -859,7 +859,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 23,
    "id": "c876fc6b",
    "metadata": {},
    "outputs": [

--- a/symred/majorana_operator.py
+++ b/symred/majorana_operator.py
@@ -412,7 +412,7 @@ class majorana_rotations():
 
         self.used_indices = None
         self.maj_rotations = None
-        self.rotated_basis = []
+        self.rotated_basis = None
 
     def _delete_reduced_rows(self, maj_op):
         z_term_check = np.logical_and(maj_op.symp_matrix[:, maj_op.even_inds],
@@ -443,6 +443,7 @@ class majorana_rotations():
     def get_rotations(self):
         self.used_indices = []
         self.maj_rotations = []
+        self.rotated_basis = []
 
         maj_basis = self.majorana_basis.cleanup().copy()
 
@@ -454,6 +455,8 @@ class majorana_rotations():
         self.used_indices = set(maj_z_pair_indices)
 
         final_terms = self._recursively_rotate(maj_basis)
+        if final_terms.n_terms!=0:
+            raise ValueError('not fully reduced')
 
         return self.rotated_basis, self.maj_rotations
 


### PR DESCRIPTION
Two things to be added. First check if input to majorana rotations is an independent basis.
Second can speed up "Clifford" rotations (Currently just does naive multiplication)