### PR TITLE
Noncontextual sets

### DIFF
--- a/.github/workflows/testing_and_coverage.yaml
+++ b/.github/workflows/testing_and_coverage.yaml
@@ -8,12 +8,12 @@ jobs:
     name: Testing and Coverage
     steps:
     - uses: actions/checkout@v1
-      with:
-          python-version: '3.9'
     - name: Installation
       run: |
         python -m pip install --upgrade pip
         pip install .
+      with:
+          python-version: '3.9'
     - name: Run tests and collect coverage
       run: | 
         pip install codecov

--- a/.github/workflows/testing_and_coverage.yaml
+++ b/.github/workflows/testing_and_coverage.yaml
@@ -8,6 +8,8 @@ jobs:
     name: Testing and Coverage
     steps:
     - uses: actions/checkout@v1
+      with:
+          python-version: '3.9'
     - name: Installation
       run: |
         python -m pip install --upgrade pip

--- a/symmer/chemistry/build_molecule.py
+++ b/symmer/chemistry/build_molecule.py
@@ -53,7 +53,7 @@ class MoleculeBuilder:
             run_mp2=run_mp2,run_cisd=run_cisd,run_ccsd=run_ccsd,run_fci=run_fci, 
             hf_method=hf_method)
         self.n_particles = self.pyscf_obj.pyscf_hf.mol.nelectron
-        if hf_method.find('RHF') != -1:
+        if self.pyscf_obj.pyscf_hf.__class__.__name__.find('RHF') != -1:
             n_electron = self.pyscf_obj.pyscf_hf.mol.nelectron
             self.n_alpha = self.n_beta = n_electron//2
         else:

--- a/symmer/projection/utils.py
+++ b/symmer/projection/utils.py
@@ -51,7 +51,7 @@ def update_eigenvalues(
     stabilizers.coeff_vec = (-1) ** np.count_nonzero(
         np.bitwise_and(
             reconstruction, 
-            basis.coeff_vec==-1
+            np.asarray(basis.coeff_vec)==-1
         ),
         axis=1
     )

--- a/symmer/symplectic/stabilizer_op.py
+++ b/symmer/symplectic/stabilizer_op.py
@@ -88,6 +88,8 @@ class StabilizerOp(PauliwordOp):
         cref_matrix = _cref_binary(to_reduce)
         S_symp = cref_matrix[PwordOp.n_terms:,np.all(~cref_matrix[:PwordOp.n_terms], axis=0)].T
         S = cls(S_symp, np.ones(S_symp.shape[0]))
+        if S.n_terms==0:
+            raise RuntimeError('The input PauliwordOp has no Z2 symmetries.')
         if commuting_override:
             return S
         else:


### PR DESCRIPTION
Sizeable change to ContextualSubspace - introduced the new StabilizeFirst noncontextual strategy which is conceptually different from the existing methods. This works on the premise that a set of stabilizers has already been identified (for example, through an auxiliary operator preserving scheme) and therefore we construct a noncontextual operator that respects these.