### PR TITLE
Updating Symmer Codebase Documentation following Google Styles

### DIFF
--- a/symmer/command_line.py
+++ b/symmer/command_line.py
@@ -37,12 +37,11 @@ def check_path_to_file(potential_path: str) -> str:
 
 
 def command_interface():
-    """Parse arguments from command line interface.
+    """
+    Parse arguments from command line interface.
 
     test:
     python command_line.py taper --config ~/Documents/PhD/SymRed/tests/yaml_input/H2_JW_real.yaml
-
-
     """
 
     parser = argparse.ArgumentParser(description="Output directory.")
@@ -131,7 +130,9 @@ def command_interface():
 
 
 def cli() -> None:
-    """command line interface"""
+    """
+    command line interface
+    """
     args = command_interface()
 
     output_data = {}

--- a/symmer/evolution/decomposition.py
+++ b/symmer/evolution/decomposition.py
@@ -12,8 +12,17 @@ warnings.filterwarnings("ignore", category=DeprecationWarning)
 ##############################################
 
 def qasm_to_PauliwordOp(qasm: str, reverse=False, combine=True) -> PauliwordOp:
-    """ Decompose an QASM circuit into a linear combination of Pauli 
+    """ 
+    Decompose an QASM circuit into a linear combination of Pauli 
     operators via the gate definitions in evolution.gate_library.
+
+    Args:
+        qasm (str): QASM circuit which you want to convert into  a linear combination of Pauli operators.
+        reverse (bool): If 'True' then flip qubit ordering and negate angles (for consistency with Qiskit). By default it's set to 'False'.
+        combine (bool): If 'True' then take product over gateset - obscures gate contributions in resulting PauliwordOp. By default it's set to 'True'.
+
+    Returns:
+        A linear combination of Pauli operators representing QASM circuit.
     """
     gate_map = {
         'x':X, 'y':Y, 'z':Z, 'h':Had, 'rx':RX, 'ry':RY, 
@@ -74,8 +83,15 @@ def qasm_to_PauliwordOp(qasm: str, reverse=False, combine=True) -> PauliwordOp:
 ####################################################
 
 def PauliwordOp_to_instructions(PwordOp) -> Dict[int, Dict[str, List[int]]]:
-        """ Stores a dictionary of gate instructions at each step, where each value
-        is a dictionary indicating the indices on which to apply each H,S,CNOT and RZ gate
+        """ 
+        Stores a dictionary of gate instructions at each step, where each value
+        is a dictionary indicating the indices on which to apply each H,S,CNOT and RZ gate.
+
+        Args:
+            PwordOp (PauliWordOp): PauliwordOp which has to be converted into Trotterized circuit instructions.
+
+        Returns:
+            circuit_instructions (dict): Trotterized circuit
         """
         circuit_instructions = {}
         for step, (X,Z) in enumerate(zip(PwordOp.X_block, PwordOp.Z_block)):
@@ -101,16 +117,30 @@ def PauliwordOp_to_QuantumCircuit(
     ) -> QuantumCircuit:
     """
     Convert the operator to a QASM circuit string for input 
-    into quantum computing packages such as Qiskit and Cirq
+    into quantum computing packages such as Qiskit and Cirq.
 
-    basis_change_indices in form [X_indices, Y_indices]
+    Args:
+        PwordOp (PauliwordOp): PauliwordOp which has to be converted into Quantum Circuit.
+        ref_state (np.array): Reference State. By default, it is set to None.
+        basis_change_indices (Dict[str, List[int]]): Basis change indices in form [X_indices, Y_indices].
+        trotter_number (int): Trotter Number. By default, it's set to 1.
+        bind_params (bool): If 'True', parameters are binded. By default it's set to 'True'.
+        include_barriers (bool): If 'True', the quantum circuit includes barriers. By default it's set to 'True'.
+        parameter_label (str): Parameter label. By default it's set to 'P'.
+
+    Returns:
+        Quantum Circuit representation of Operator
     """
     if isinstance(ref_state, QuantumState):
         assert ref_state.n_terms == 1
         ref_state = ref_state.state_matrix[0]
 
     def qiskit_ordering(indices):
-        """ we index from left to right - in Qiskit this ordering is reversed
+        """ 
+        We index from left to right - in Qiskit this ordering is reversed.
+
+        Args:
+            indices (int): Indices
         """
         return PwordOp.n_qubits - 1 - indices
 
@@ -172,9 +202,14 @@ def PauliwordOp_to_QuantumCircuit(
     return qc
 
 def get_CNOT_connectivity_graph(evolution_obj: Union[PauliwordOp, QuantumCircuit], print_graph=False):
-    """ Get the graph whoss edges denote nonlocal interaction between two qubits.
+    """ 
+    Get the graph whoss edges denote nonlocal interaction between two qubits.
     This is useful for device-aware ansatz construction to ensure the circuit connectiviy
     may be accomodated by the topology of the target quantum processor. 
+
+    Args:
+        evolution_obj (Union[PauliwordOp, QuantumCircuit]): Evolution Object
+        print_graph (bool): If True, the graph is drawn. By default, it's set to False.
     """
     if isinstance(evolution_obj, PauliwordOp):
         qc = PauliwordOp_to_QuantumCircuit(evolution_obj)

--- a/symmer/evolution/exponentiation.py
+++ b/symmer/evolution/exponentiation.py
@@ -5,7 +5,7 @@ from symmer.operators import PauliwordOp
 
 def exponentiate_single_Pop(P: PauliwordOp) -> PauliwordOp:
     """
-     Exponentiate a single Pauli term as e^{P}
+    Exponentiate a single Pauli term as e^{P}
 
     If goal is to implement e^{iθP} then coefficient of P must be iθ (note imaginary part must be included in coeff)
 
@@ -13,7 +13,6 @@ def exponentiate_single_Pop(P: PauliwordOp) -> PauliwordOp:
         P (PauliwordOp): Pauli operator to exponentiate
     Returns
         exp_P (PauliwordOp): PauliwordOp representation of exponentiated operator
-
     """
     assert(P.n_terms == 1), 'Can only exponentiate single Pauli terms'
     P_copy = P.copy()
@@ -25,7 +24,8 @@ def exponentiate_single_Pop(P: PauliwordOp) -> PauliwordOp:
     return exp_P
 
 def trotter(op:PauliwordOp, trotnum:int=1) -> PauliwordOp:
-    """ Computes the exponential exp(op). This is exact only when 
+    """ 
+    Computes the exponential exp(op). This is exact only when 
     op is fully commuting, otherwise approximates the exponential
     and increasing trotnum will improve precision.
     """

--- a/symmer/evolution/exponentiation.py
+++ b/symmer/evolution/exponentiation.py
@@ -11,7 +11,7 @@ def exponentiate_single_Pop(P: PauliwordOp) -> PauliwordOp:
 
     Args:
         P (PauliwordOp): Pauli operator to exponentiate
-    Returns
+    Returns:
         exp_P (PauliwordOp): PauliwordOp representation of exponentiated operator
     """
     assert(P.n_terms == 1), 'Can only exponentiate single Pauli terms'
@@ -28,6 +28,10 @@ def trotter(op:PauliwordOp, trotnum:int=1) -> PauliwordOp:
     Computes the exponential exp(op). This is exact only when 
     op is fully commuting, otherwise approximates the exponential
     and increasing trotnum will improve precision.
+
+    Args:
+        op (PauliwordOp): Pauli operator to exponentiate
+        tortnum (int): Increasing trotnum will improve precision when exact exponential is not computed. By default, it is set to 1.
     """
     op_copy = op.copy().multiply_by_constant(1/trotnum)
     factors = [exponentiate_single_Pop(P) for P in op_copy]*trotnum

--- a/symmer/evolution/gate_library.py
+++ b/symmer/evolution/gate_library.py
@@ -7,23 +7,69 @@ from symmer.evolution import trotter
 #############################################
 
 def I(n_qubits:int) -> PauliwordOp:
+    """
+    Identity gate
+
+    Args:
+        n_qubits (int): Number of qubits
+
+    Returns:
+        PauliwordOp representing the identity operation ('I') applied to a system of 'n_qubits'.
+    """
     return PauliwordOp.from_dictionary({'I'*n_qubits:1})
 
 def X(n_qubits:int, index:int) -> PauliwordOp:
+    """
+    Pauli X gate
+
+    Args:
+        n_qubits (int): Number of qubits.
+        index (int): Qubit index at which the operation 'X' has to be applied.
+
+    Returns:
+        PauliwordOp representing the Pauli 'X' operator applied to the specified qubit index while leaving the other qubits unchanged.
+    """
     X_str = ['I']*n_qubits; X_str[index] = 'X'
     return PauliwordOp.from_dictionary({''.join(X_str):1})
 
 def Y(n_qubits:int, index:int) -> PauliwordOp:
+    """
+    Pauli Y gate
+
+    Args:
+        n_qubits (int): Number of qubits.
+        index (int): Qubit index at which the operation 'Y' has to be applied.
+
+    Returns:
+        PauliwordOp representing the Pauli 'Y' operator applied to the specified qubit index while leaving the other qubits unchanged.
+    """
     Y_str = ['I']*n_qubits; Y_str[index] = 'Y'
     return PauliwordOp.from_dictionary({''.join(Y_str):1})
 
 def Z(n_qubits:int, index:int) -> PauliwordOp:
+    """
+    Pauli Z gate
+
+    Args:
+        n_qubits (int): Number of qubits.
+        index (int): Qubit index at which the operation 'Z' has to be applied.
+
+    Returns:
+        PauliwordOp representing the Pauli 'Z' operator applied to the specified qubit index while leaving the other qubits unchanged.
+    """
     Z_str = ['I']*n_qubits; Z_str[index] = 'Z'
     return PauliwordOp.from_dictionary({''.join(Z_str):1})
 
 def Had(n_qubits:int, index:int) -> PauliwordOp:
     """ 
     Hadamard gate
+
+    Args:
+        n_qubits (int): Number of qubits.
+        index (int): Qubit index at which the operation 'H' has to be applied.
+
+    Returns:
+        PauliwordOp representing the 'H' operator applied to the specified qubit index while leaving the other qubits unchanged.
     """
     return (
         Z(n_qubits, index).multiply_by_constant(1/np.sqrt(2))+
@@ -33,6 +79,14 @@ def Had(n_qubits:int, index:int) -> PauliwordOp:
 def CZ(n_qubits:int, control:int, target:int) -> PauliwordOp:
     """ 
     Controlled Z gate
+
+    Args:
+        n_qubits (int): Number of qubits.
+        control (int): Qubit index at which will act as a control qubit.
+        target (int): Qubit index at which the operation 'Z' has to be applied if the control qubit is in |1> state.
+
+    Returns:
+        PauliwordOp representing the Controlled-Z (CZ) gate applied to the specified control and target qubits in a system of 'n_qubits' qubits.
     """
     ZI = Z(n_qubits, control)
     IZ = Z(n_qubits, target)
@@ -45,21 +99,83 @@ def CZ(n_qubits:int, control:int, target:int) -> PauliwordOp:
 def CX(n_qubits:int, control:int, target:int) -> PauliwordOp:
     """ 
     Controlled X gate
+
+    Args:
+        n_qubits (int): Number of qubits.
+        control (int): Qubit index at which will act as a control qubit.
+        target (int): Qubit index at which the operation 'X' has to be applied if the control qubit is in |1> state.
+
+    Returns:
+        PauliwordOp representing the Controlled-X (CX) gate applied to the specified control and target qubits in a system of 'n_qubits' qubits.
     """
     _Had = Had(n_qubits, target)
     return _Had * CZ(n_qubits, control, target) * _Had
 
 def RX(n_qubits:int, index:int, angle:float) -> PauliwordOp:
+    """ 
+    Rotation-X gate
+
+    Args:
+        n_qubits (int): Number of qubits.
+        index (int): Qubit index at which the operation 'RX' has to be applied.
+        angle (float): The angle by which the qubit state has to be rotated around the X-axis.
+
+    Returns:
+        PauliwordOp representing the rotation around the X-axis (RX) gate by the specified angle applied to a specific qubit in a system of 'n_qubits'.
+    """
     return trotter(X(n_qubits, index).multiply_by_constant(1j*angle/2))
 
 def RY(n_qubits:int, index:int, angle:float) -> PauliwordOp:
+    """ 
+    Rotation-Y gate
+
+    Args:
+        n_qubits (int): Number of qubits.
+        index (int): Qubit index at which the operation 'RY' has to be applied.
+        angle (float): The angle by which the qubit state has to be rotated around the Y-axis.
+
+    Returns:
+        PauliwordOp representing the rotation around the Y-axis (RY) gate by the specified angle applied to a specific qubit in a system of 'n_qubits'.
+    """
     return trotter(Y(n_qubits, index).multiply_by_constant(1j*angle/2))
 
 def RZ(n_qubits:int, index:int, angle:float) -> PauliwordOp:
+    """ 
+    Rotation-Z gate
+
+    Args:
+        n_qubits (int): Number of qubits.
+        index (int): Qubit index at which the operation 'RZ' has to be applied.
+        angle (float): The angle by which the qubit state has to be rotated around the Z-axis.
+
+    Returns:
+        PauliwordOp representing the rotation around the Z-axis (RZ) gate by the specified angle applied to a specific qubit in a system of 'n_qubits'.
+    """
     return trotter(Z(n_qubits, index).multiply_by_constant(1j*angle/2))
 
 def U1(n_qubits:int, index:int, angle:float) -> PauliwordOp:
+    """ 
+    U1 gate
+
+    Args:
+        n_qubits (int): Number of qubits.
+        index (int): Qubit index at which the phase shift is to be introduced to the qubit state.
+        angle (float): Phase angle.
+
+    Returns:
+        PauliwordOp representing the U1 gate with phase 'angle' applied to a specific qubit in a system of 'n_qubits'.
+    """
     return RZ(n_qubits, index, angle).multiply_by_constant(np.exp(1j*angle/2))
 
 def S(n_qubits:int, index:int) -> PauliwordOp:
+    """
+    S gate
+
+    Args:
+        n_qubits (int): Number of qubits.
+        index (int): Qubit index at which the operation 'S' has to be applied.
+
+    Returns:
+        PauliwordOp representing the 'S' operator applied to the specified qubit index while leaving the other qubits unchanged.
+    """
     return RZ(n_qubits,index,-np.pi/2).multiply_by_constant(np.sqrt(1j))

--- a/symmer/evolution/gate_library.py
+++ b/symmer/evolution/gate_library.py
@@ -22,7 +22,8 @@ def Z(n_qubits:int, index:int) -> PauliwordOp:
     return PauliwordOp.from_dictionary({''.join(Z_str):1})
 
 def Had(n_qubits:int, index:int) -> PauliwordOp:
-    """ Hadamard gate
+    """ 
+    Hadamard gate
     """
     return (
         Z(n_qubits, index).multiply_by_constant(1/np.sqrt(2))+
@@ -30,7 +31,8 @@ def Had(n_qubits:int, index:int) -> PauliwordOp:
     )
 
 def CZ(n_qubits:int, control:int, target:int) -> PauliwordOp:
-    """ Controlled Z gate
+    """ 
+    Controlled Z gate
     """
     ZI = Z(n_qubits, control)
     IZ = Z(n_qubits, target)
@@ -41,7 +43,8 @@ def CZ(n_qubits:int, control:int, target:int) -> PauliwordOp:
     return CZ
 
 def CX(n_qubits:int, control:int, target:int) -> PauliwordOp:
-    """ Controlled X gate
+    """ 
+    Controlled X gate
     """
     _Had = Had(n_qubits, target)
     return _Had * CZ(n_qubits, control, target) * _Had

--- a/symmer/evolution/variational_optimization.py
+++ b/symmer/evolution/variational_optimization.py
@@ -42,7 +42,8 @@ class VQE_Driver:
             self.circuit = ansatz_circuit
 
     def prepare_for_evolution(self, excitation_ops: PauliwordOp) -> None:
-        """ Save the excitation generators and construct corresponding ansatz circuit
+        """ 
+        Save the excitation generators and construct corresponding ansatz circuit
         """
         self.excitation_generators = PauliwordOp(
             excitation_ops.symp_matrix, np.ones(excitation_ops.n_terms)
@@ -55,7 +56,8 @@ class VQE_Driver:
             evolution_obj: Union[QuantumCircuit, PauliwordOp], 
             x: np.array
         ) -> Union[np.array, QuantumState, List[Tuple[PauliwordOp, float]]]:
-        """ Given a quantum circuit or excitation generating set, return the relevant state-type object:
+        """ 
+        Given a quantum circuit or excitation generating set, return the relevant state-type object:
         - Array of the QuantumCircuit (for sparse/dense array methods)
         - QuantumState representation of the QuantumCircuit (for symbolic methods)
         - Rotations of the form [(generator, angle)] for the observable_rotation expectation_eval method
@@ -76,7 +78,8 @@ class VQE_Driver:
            observable: PauliwordOp, 
            state: Union[np.array, QuantumState, List[Tuple[PauliwordOp, float]]]
         ) -> float:
-        """ Given an observable and state in the relevant form for the
+        """ 
+        Given an observable and state in the relevant form for the
         expectation value method, calculate the expectation value and return
         """
         if self.expectation_eval == 'dense_array':
@@ -91,7 +94,8 @@ class VQE_Driver:
             return (self.ref_state.dagger * observable.perform_rotations(state) * self.ref_state).real
         
     def f(self, x: np.array) -> float:
-        """ Given a parameter vector, bind to the circuit and retrieve expectation value
+        """ 
+        Given a parameter vector, bind to the circuit and retrieve expectation value
         """
         if self.expectation_eval == 'observable_rotation':
             state = self.get_state(self.excitation_generators, x)
@@ -100,7 +104,8 @@ class VQE_Driver:
         return self._f(self.observable, state)
         
     def partial_derivative(self, x: np.array, param_index: int) -> float:
-        """ Get the partial derivative with respect to an ansatz parameter
+        """ 
+        Get the partial derivative with respect to an ansatz parameter
         by the parameter shift rule.
         """
         x_upper = x.copy(); x_upper[param_index]+=np.pi/4
@@ -108,7 +113,8 @@ class VQE_Driver:
         return self.f(x_upper) - self.f(x_lower)
     
     def gradient(self, x: np.array) -> np.array:
-        """ Get the ansatz parameter gradient, i.e. the vector of partial derivatives.
+        """ 
+        Get the ansatz parameter gradient, i.e. the vector of partial derivatives.
         """
         if self.expectation_eval.find('projector') == -1:
             with mp.Pool(mp.cpu_count()) as pool:
@@ -122,7 +128,8 @@ class VQE_Driver:
         return np.asarray(grad_vec)
     
     def run(self, x0:np.array=None, **kwargs):
-        """ Run the VQE routine
+        """ 
+        Run the VQE routine
         """
         if x0 is None:
             x0 = np.random.random(self.circuit.num_parameters)
@@ -167,7 +174,8 @@ class VQE_Driver:
         return serialize_opt_data(opt_out), vqe_history
 
 class ADAPT_VQE(VQE_Driver):
-    """ Performs qubit-ADAPT-VQE (https://doi.org/10.1103/PRXQuantum.2.020310), a 
+    """ 
+    Performs qubit-ADAPT-VQE (https://doi.org/10.1103/PRXQuantum.2.020310), a 
     variant of ADAPT-VQE (https://doi.org/10.1038/s41467-019-10988-2) that takes 
     its excitation pool as Pauli operators (mapped via some transformation such 
     as Jordan-Wigner) instead of the originating fermionic operators.
@@ -225,7 +233,8 @@ class ADAPT_VQE(VQE_Driver):
         return self._f(self.observable,upper_state) - self._f(self.observable,lower_state)
 
     def pool_gradient(self):
-        """ Get the operator pool gradient by calculating the derivative with respect to
+        """ 
+        Get the operator pool gradient by calculating the derivative with respect to
         each element of the pool. This is parallelized for all but the symbolic_projector
         expectation value calculation method as that is already multiprocessed and therefore
         would result in nested daemonic processes.
@@ -256,7 +265,8 @@ class ADAPT_VQE(VQE_Driver):
         return np.asarray(gradient)
     
     def pool_score(self):
-        """ Score the operator pool with respect to gradients and circuit linearity
+        """ 
+        Score the operator pool with respect to gradients and circuit linearity
         """
         scores = abs(self.pool_gradient())
 
@@ -280,7 +290,8 @@ class ADAPT_VQE(VQE_Driver):
         return scores
         
     def append_to_adapt_operator(self, excitations_to_append: List[PauliwordOp]):
-        """ Append the input term(s) to the expanding adapt_operator
+        """ 
+        Append the input term(s) to the expanding adapt_operator
         """
         for excitation in excitations_to_append:
             if ~np.any(self.adapt_operator.symp_matrix):
@@ -292,7 +303,8 @@ class ADAPT_VQE(VQE_Driver):
             max_cycles:int=10, gtol:float=1e-3, atol:float=1e-10, 
             target:float=0, target_error:float=1e-3
         ):
-        """ Perform the ADAPT-VQE optimization
+        """ 
+        Perform the ADAPT-VQE optimization
         gtol: gradient throeshold below which optimization will terminate
         atol: if the difference between successive expectation values is below this threshold, terminate
         max_cycles: maximum number of ADAPT cycles to perform

--- a/symmer/evolution/variational_optimization.py
+++ b/symmer/evolution/variational_optimization.py
@@ -14,13 +14,18 @@ import multiprocessing as mp
 from typing import *
 
 class VQE_Driver:
+    """
+    expectation value method one of the following choices:
+        - symbolic_direct: uses symmer to compute <psi|H|psi> directly using the QuantumState class
+        - symbolic_projector: computes expval by projecting onto +-1 eigenspaces of observable terms
+        - observable_rotation: implements the circuit as rotations applied to the observable
+        - sparse_array: direct calcaultion by converting observable/state to sparse array
+        - dense_array: direct calcaultion by converting observable/state to dense array
     
-    # expectation value method one of the following choices:
-    # symbolic_direct: uses symmer to compute <psi|H|psi> directly using the QuantumState class
-    # symbolic_projector: computes expval by projecting onto +-1 eigenspaces of observable terms
-    # observable_rotation: implements the circuit as rotations applied to the observable
-    # sparse_array: direct calcaultion by converting observable/state to sparse array
-    # dense_array: direct calcaultion by converting observable/state to dense array
+    Attributes:
+        expectation_eval (str): expectation value method. Its default value is 'symbolic_direct'.
+        verbose (bool): If True, prints out useful information during computation. By default it is set to 'True'.
+    """
     expectation_eval = 'symbolic_direct'
     # prints out useful information during computation:
     verbose = True
@@ -31,6 +36,13 @@ class VQE_Driver:
         excitation_ops: PauliwordOp = None,
         ref_state: QuantumState = None
         ) -> None:
+        """
+        Args:
+            observable (PauliwordOp): Observables
+            ansatz_circuit (QuantumCircuit): Ansatz Circuit. By default, it's set to 'None'.
+            excitation_ops (PauliwordOp): Excitation Operators. By default, it's set to 'None'.
+            ref_state (QuantumState): Reference State. By default, it's set to 'None'.
+        """
         self.observable = observable
         self.ref_state = ref_state
         # observables must have real coefficients over the Pauli group:
@@ -43,7 +55,10 @@ class VQE_Driver:
 
     def prepare_for_evolution(self, excitation_ops: PauliwordOp) -> None:
         """ 
-        Save the excitation generators and construct corresponding ansatz circuit
+        Save the excitation generators and construct corresponding ansatz circuit.
+
+        Args:
+            excitation_ops (PauliwordOp): Excitation Operators.
         """
         self.excitation_generators = PauliwordOp(
             excitation_ops.symp_matrix, np.ones(excitation_ops.n_terms)
@@ -57,11 +72,14 @@ class VQE_Driver:
             x: np.array
         ) -> Union[np.array, QuantumState, List[Tuple[PauliwordOp, float]]]:
         """ 
-        Given a quantum circuit or excitation generating set, return the relevant state-type object:
-        - Array of the QuantumCircuit (for sparse/dense array methods)
-        - QuantumState representation of the QuantumCircuit (for symbolic methods)
-        - Rotations of the form [(generator, angle)] for the observable_rotation expectation_eval method
-        
+        Args:
+            evolution_obj (Union[QuantumCircuit, PauliwordOp]): Evoluation object is either a Quantum Circuit (QuantumCircuit) or a Excitation Generating Set(PauliwordOp).
+
+        Returns:
+            Given a quantum circuit or excitation generating set, return the relevant state-type object:
+            - Array (np.array) of the QuantumCircuit (for sparse/dense array methods).
+            - Quantum State (QuantumState) representation of the QuantumCircuit (for symbolic methods).
+            - Rotations of the form [(generator, angle)] for the observable_rotation expectation_eval method.
         """
         if self.expectation_eval == 'observable_rotation':
             return list(zip(evolution_obj, -2*x))
@@ -80,7 +98,17 @@ class VQE_Driver:
         ) -> float:
         """ 
         Given an observable and state in the relevant form for the
-        expectation value method, calculate the expectation value and return
+        expectation value method, calculate the expectation value and return.
+
+        Args:
+            observable (PauliwordOp): Observable
+            state: State-type object. It can be:
+                - Array (np.array) of the QuantumCircuit (for sparse/dense array methods).
+                - Quantum State (QuantumState) representation of the QuantumCircuit (for symbolic methods).
+                - Rotations of the form [(generator, angle)] for the observable_rotation expectation_eval method.
+        
+        Returns:
+            Expectation Value (float)
         """
         if self.expectation_eval == 'dense_array':
             return (state.conjugate().T @ observable.to_sparse_matrix.toarray() @ state)[0,0].real
@@ -95,7 +123,13 @@ class VQE_Driver:
         
     def f(self, x: np.array) -> float:
         """ 
-        Given a parameter vector, bind to the circuit and retrieve expectation value
+        Given a parameter vector, bind to the circuit and retrieve expectation value.
+
+        Args:
+            x (np.array): Parameter vector
+
+        Returns:
+            Expectation Value (float)
         """
         if self.expectation_eval == 'observable_rotation':
             state = self.get_state(self.excitation_generators, x)
@@ -107,6 +141,13 @@ class VQE_Driver:
         """ 
         Get the partial derivative with respect to an ansatz parameter
         by the parameter shift rule.
+
+        Args:
+            x (np.array): Parameter vector
+            param_index (int): Prarameter index
+        
+        Returns:
+            Partial derivative(float) with respect to an ansatz parameter.
         """
         x_upper = x.copy(); x_upper[param_index]+=np.pi/4
         x_lower = x.copy(); x_lower[param_index]-=np.pi/4
@@ -115,6 +156,12 @@ class VQE_Driver:
     def gradient(self, x: np.array) -> np.array:
         """ 
         Get the ansatz parameter gradient, i.e. the vector of partial derivatives.
+
+        Args:
+            x (np.array): Parameter vector
+        
+        Returns:
+            Ansatz parameter gradient (np.array)
         """
         if self.expectation_eval.find('projector') == -1:
             with mp.Pool(mp.cpu_count()) as pool:
@@ -129,7 +176,10 @@ class VQE_Driver:
     
     def run(self, x0:np.array=None, **kwargs):
         """ 
-        Run the VQE routine
+        Run the VQE routine.
+        
+        Args:
+            x0 (np.array): Parameter vector
         """
         if x0 is None:
             x0 = np.random.random(self.circuit.num_parameters)
@@ -179,6 +229,12 @@ class ADAPT_VQE(VQE_Driver):
     variant of ADAPT-VQE (https://doi.org/10.1038/s41467-019-10988-2) that takes 
     its excitation pool as Pauli operators (mapped via some transformation such 
     as Jordan-Wigner) instead of the originating fermionic operators.
+
+    Attributes:
+        derivative_eval (str): Method which is to be used to calculate the operator pool derivatives.
+        TETRIS (bool): If True, TETRIS-ADAPT-VQE is performed. By default it is set to False.
+        linearity_biased (bool): If True, linearity-biased-ADAPT-VQE is performed. By default it is set to True.
+        bias (float): Bias value used in linearity-biased-ADAPT-VQE. It's default value is 1/3.
     """
     # method by which to calculate the operator pool derivatives, either
     # commutators: compute the commutator of the observable with each pool element
@@ -196,6 +252,12 @@ class ADAPT_VQE(VQE_Driver):
         excitation_pool: PauliwordOp = None,
         ref_state: QuantumState = None
         ) -> None:
+        """
+        Args:
+            observable (PauliwordOp): Observable
+            excitation_pool (PauliwordOp): Excitation pool as Pauli operators. By default, it's set to 'None'.
+            ref_state (QuantumState): Reference State. By default, it's set to 'None'.
+        """
         super().__init__(
             observable     = observable,
             excitation_ops = PauliwordOp.empty(observable.n_qubits),
@@ -210,20 +272,38 @@ class ADAPT_VQE(VQE_Driver):
       
     @cached_property
     def commutators(self) -> List[PauliwordOp]:
-        """ List of commutators [H, P] where P is some operator pool element
+        """ 
+        List of commutators [H, P] where P is some operator pool element.
+
+        Returns:
+            List of commutators [H, P]
         """
         with mp.Pool(mp.cpu_count()) as pool:
             commutators = pool.map(self.observable.commutator, self.excitation_pool)
         return list(map(lambda x:x*1j, commutators))
         
     def _derivative_from_commutators(self, index: int) -> float:
-        """ Calculate derivative using the commutator method
+        """ 
+        Calculate derivative using the commutator method.
+
+        Args:
+            index (int): Index
+
+        Returns:
+            Derivative (float) using the commutator method.
         """
         assert self.current_state is not None
         return self._f(observable=self.commutators[index], state=self.current_state) 
     
     def _derivative_from_param_shift(self, index):
-        """ Calculate the derivative using the parameter shift rule
+        """ 
+        Calculate the derivative using the parameter shift rule.
+
+         Args:
+            index (int): Index
+
+        Returns:
+            Derivative (float) using the parameter shift rule.
         """
         adapt_op_temp = self.adapt_operator.append(self.excitation_pool[index])
         circuit_temp = PauliwordOp_to_QuantumCircuit(
@@ -238,6 +318,9 @@ class ADAPT_VQE(VQE_Driver):
         each element of the pool. This is parallelized for all but the symbolic_projector
         expectation value calculation method as that is already multiprocessed and therefore
         would result in nested daemonic processes.
+
+        Returns:
+            Operator pool gradient (np.array)
         """
         if self.derivative_eval == 'commutators':
             self.commutators # to ensure this has been cached, else nested daemonic process occurs            
@@ -266,7 +349,7 @@ class ADAPT_VQE(VQE_Driver):
     
     def pool_score(self):
         """ 
-        Score the operator pool with respect to gradients and circuit linearity
+        Score the operator pool with respect to gradients and circuit linearity.
         """
         scores = abs(self.pool_gradient())
 
@@ -291,7 +374,7 @@ class ADAPT_VQE(VQE_Driver):
         
     def append_to_adapt_operator(self, excitations_to_append: List[PauliwordOp]):
         """ 
-        Append the input term(s) to the expanding adapt_operator
+        Append the input term(s) to the expanding adapt_operator.
         """
         for excitation in excitations_to_append:
             if ~np.any(self.adapt_operator.symp_matrix):
@@ -305,11 +388,13 @@ class ADAPT_VQE(VQE_Driver):
         ):
         """ 
         Perform the ADAPT-VQE optimization
-        gtol: gradient throeshold below which optimization will terminate
-        atol: if the difference between successive expectation values is below this threshold, terminate
-        max_cycles: maximum number of ADAPT cycles to perform
-        target: if a target energy is known, this may be specified here
-        target_error: the absoluate error threshold with respect to the target energy 
+
+        Args:
+            gtol: gradient throeshold below which optimization will terminate
+            atol: if the difference between successive expectation values is below this threshold, terminate
+            max_cycles: maximum number of ADAPT cycles to perform
+            target: if a target energy is known, this may be specified here
+            target_error: the absoluate error threshold with respect to the target energy 
         """
         interim_data = {'history':[]}
         adapt_cycle=1

--- a/symmer/operators/anticommuting_op.py
+++ b/symmer/operators/anticommuting_op.py
@@ -9,6 +9,14 @@ class AntiCommutingOp(PauliwordOp):
     def __init__(self,
                  AC_op_symp_matrix: np.array,
                  coeff_list: np.array):
+        """
+        Args:
+            AC_op_symp_matrix (np.array): The symmetric matrix representation of the anti-commuting operator.
+            coeff_list (np.array): The coefficient list associated with the anti-commuting operator.
+
+        Raises:
+            AssertionError: If the operators do not anticommute.
+        """
         super().__init__(AC_op_symp_matrix, coeff_list)
 
         # check all operators anticommute
@@ -23,6 +31,15 @@ class AntiCommutingOp(PauliwordOp):
             pauli_terms :List[str],
             coeff_vec:   List[complex] = None
         ) -> "AntiCommutingOp":
+        """
+        Args:
+            pauli_terms (List[str]): A list of Pauli terms represented as strings.
+            coeff_vec (List[complex], optional): A list of complex coefficients associated with the Pauli terms.
+                If not provided, the default coefficients are assumed to be 1.0 for each term.
+
+        Returns:
+            AntiCommutingOp: An AntiCommutingOp instance initialized from the list of Pauli terms.
+        """
         PwordOp = super().from_list(pauli_terms, coeff_vec)
         return cls.from_PauliwordOp(PwordOp)
 
@@ -30,7 +47,15 @@ class AntiCommutingOp(PauliwordOp):
     def from_dictionary(cls,
             operator_dict: Dict[str, complex]
         ) -> "AntiCommutingOp":
-        """ Initialize a PauliwordOp from its dictionary representation {pauli:coeff, ...}
+        """ 
+        Initialize a PauliwordOp from its dictionary representation {pauli:coeff, ...}
+
+        Args:
+            operator_dict (Dict[str, complex]): A dictionary representing the operator, where the keys are Pauli strings
+                and the values are complex coefficients.
+
+        Returns:
+            AntiCommutingOp: An AntiCommutingOp instance initialized from the dictionary representation.
         """
         PwordOp = super().from_dictionary(operator_dict)
         return cls.from_PauliwordOp(PwordOp)
@@ -39,6 +64,13 @@ class AntiCommutingOp(PauliwordOp):
     def from_PauliwordOp(cls,
             PwordOp: PauliwordOp
         ) -> 'AntiCommutingOp':
+        """
+        Args:
+            PwordOp (PauliwordOp): The PauliwordOp instance to initialize the AntiCommutingOp from.
+
+        Returns:
+            AntiCommutingOp: An AntiCommutingOp instance initialized from the given PauliwordOp.
+        """
         return cls(PwordOp.symp_matrix, PwordOp.coeff_vec)
 
 
@@ -50,7 +82,7 @@ class AntiCommutingOp(PauliwordOp):
         Note one needs to re-run this function if ordering changed (e.g. if lexicographical_sort is run)
 
         Returns:
-            s_index (int): index of least dense term in objects symp_matrix and coeff_vec
+            s_index (int): index of least dense term in objects symp_matrix and coeff_vec.
         """
         ### np.logical_or(X_block, Z_block)
         # pos_terms_occur = np.logical_or(self.symp_matrix[:, :self.n_qubits], self.symp_matrix[:, self.n_qubits:])
@@ -68,6 +100,13 @@ class AntiCommutingOp(PauliwordOp):
 
 
     def _recursive_seq_rotations(self, AC_op: PauliwordOp) -> "PauliwordOp":
+        """
+        Args:
+            AC_op (PauliwordOp): The AntiCommutingOp to apply sequence rotations to.
+
+        Returns:
+            PauliwordOp: The AntiCommutingOp after applying sequence rotations.
+        """
         if AC_op.n_terms == 1:
             return AC_op
         else:
@@ -109,7 +148,6 @@ class AntiCommutingOp(PauliwordOp):
             ## know how operator acts therefore don't need to actually do rotations
 
             return self._recursive_seq_rotations(AC_op_rotated)
-
 
     def unitary_partitioning(self, s_index: int=None, up_method: Optional[str]='seq_rot') \
             -> Tuple[PauliwordOp, Union[PauliwordOp, List[Tuple[PauliwordOp, float]]], float, "AntiCommutingOp"]:

--- a/symmer/operators/base.py
+++ b/symmer/operators/base.py
@@ -20,6 +20,9 @@ warnings.simplefilter('always', UserWarning)
 class PauliwordOp:
     """ 
     A class thats represents an operator defined over the Pauli group in the symplectic representation.
+
+    Attributes:
+        sigfig (int): The number of significant figures for printing.
     """
     sigfig = 3 # specifies the number of significant figures for printing
     
@@ -34,6 +37,10 @@ class PauliwordOp:
         dictionary representation. Operating on the level of the symplectic matrix is fastest 
         since it circumvents various conversions required - this is how the methods defined 
         below function.
+
+        Args:
+            symp_matrix (Union[List[str], Dict[str, float], np.array]): The symplectic matrix representing the operator.
+            coeff_vec (Union[List[complex], np.array]): The coefficients of the operator.
         """
         symp_matrix = np.asarray(symp_matrix)
         if symp_matrix.dtype == int:
@@ -61,7 +68,18 @@ class PauliwordOp:
             complex_coeffs: bool = True,
             density: float = 0.3
         ) -> "PauliwordOp":
-        """ Generate a random PauliwordOp with normally distributed coefficients
+        """ 
+        Generate a random PauliwordOp with normally distributed coefficients.
+
+        Args:
+            n_qubits (int): The number of qubits.
+            n_terms (int): The number of terms in the operator.
+            diagonal (bool): Whether to generate a diagonal operator (default: False).
+            complex_coeffs (bool): Whether to generate complex coefficients (default: True).
+            density (float): The density of non-zero elements in the symplectic matrix (default: 0.3).
+
+        Returns:
+            PauliwordOp: A random PauliwordOp object.
         """
         symp_matrix = random_symplectic_matrix(n_qubits, n_terms, diagonal, density=density)
         coeff_vec = np.random.randn(n_terms).astype(complex)
@@ -73,7 +91,8 @@ class PauliwordOp:
     def haar_random(cls,
             n_qubits: int,
         ) -> "PauliwordOp":
-        """ Generate a Haar random U(N) matrix (N^n_qubits) as a linear combination of Pauli operators.
+        """ 
+        Generate a Haar random U(N) matrix (N^n_qubits) as a linear combination of Pauli operators.
         aka generate a uniform random unitary from a Hilbert space.
 
         Args:
@@ -90,7 +109,14 @@ class PauliwordOp:
             pauli_terms :List[str], 
             coeff_vec:   List[complex] = None
         ) -> "PauliwordOp":
-        """ Initialize a PauliwordOp from its Pauli terms and coefficients stored as lists
+        """ 
+        Initialize a PauliwordOp from its Pauli terms and coefficients stored as lists.
+
+        Args:
+            operator_dict (Dict[str, complex]): A dictionary representing the PauliwordOp.
+
+        Returns:
+            PauliwordOp: A new PauliwordOp object.
         """
         n_rows = len(pauli_terms)
         if coeff_vec is None:
@@ -116,7 +142,14 @@ class PauliwordOp:
     def from_dictionary(cls,
             operator_dict: Dict[str, complex]
         ) -> "PauliwordOp":
-        """ Initialize a PauliwordOp from its dictionary representation {pauli:coeff, ...}
+        """ 
+        Initialize a PauliwordOp from its dictionary representation {pauli:coeff, ...}
+
+        Args:
+            operator_dict (Dict[str, complex]): A dictionary representing the PauliwordOp.
+
+        Returns:
+            PauliwordOp: A new PauliwordOp object.
         """
         pauli_terms, coeff_vec = zip(*operator_dict.items())
         pauli_terms = list(pauli_terms)
@@ -127,7 +160,16 @@ class PauliwordOp:
             openfermion_op: QubitOperator,
             n_qubits = None
         ) -> "PauliwordOp":
-        """ Initialize a PauliwordOp from OpenFermion's QubitOperator representation
+        """ 
+        Initialize a PauliwordOp from OpenFermion's QubitOperator representation.
+
+        Args:
+            openfermion_op (QubitOperator): The QubitOperator to initialize from.
+            n_qubits (int, optional): The number of qubits. If not provided, it is determined
+                from the QubitOperator. Defaults to None.
+
+        Returns:
+            PauliwordOp: A new PauliwordOp object.
         """
         assert(isinstance(openfermion_op, QubitOperator)), 'Must supply a QubitOperator'
         if n_qubits is None:
@@ -142,7 +184,14 @@ class PauliwordOp:
     def from_qiskit(cls,
             qiskit_op: ibm_PauliSumOp
         ) -> "PauliwordOp":
-        """ Initialize a PauliwordOp from Qiskit's PauliSumOp representation
+        """ 
+        Initialize a PauliwordOp from Qiskit's PauliSumOp representation.
+
+        Args:
+            qiskit_op (ibm_PauliSumOp): The PauliSumOp to initialize from.
+
+        Returns:
+            PauliwordOp: A new PauliwordOp object.
         """
         assert(isinstance(qiskit_op, ibm_PauliSumOp)), 'Must supply a PauliSumOp'
         operator_dict = PauliSumOp_to_dict(
@@ -154,7 +203,14 @@ class PauliwordOp:
     def empty(cls, 
             n_qubits: int
         ) -> "PauliwordOp":
-        """ Initialize an empty PauliwordOp of the form 0 * I...I
+        """ 
+        Initialize an empty PauliwordOp of the form 0 * I...I
+
+        Args:
+            n_qubits (int): The number of qubits.
+
+        Returns:
+            PauliwordOp: A new PauliwordOp object.
         """
         return cls.from_dictionary({'I'*n_qubits:0})
 
@@ -164,6 +220,14 @@ class PauliwordOp:
             n_qubits: int,
             operator_basis: "PauliwordOp" = None
         ) -> "PauliwordOp":
+        """
+        Args:
+            n_qubits (int): The number of qubits.
+            operator_basis (PauliwordOp, optional): The operator basis to use. Default is 'None'.
+
+        Returns:
+            PauliwordOp: A new PauliwordOp object.
+        """
         if operator_basis is None:
             # fast method to build all binary assignments
             int_list = np.arange(4 ** (n_qubits))
@@ -216,6 +280,12 @@ class PauliwordOp:
             n_qubits: int
         ) -> "PauliwordOp":
         """
+        Args:
+            matrix (Union[np.array, csr_matrix]): The matrix to decompose.
+            n_qubits (int): The number of qubits.
+
+        Returns:
+            PauliwordOp: A new PauliwordOp object representing the decomposition of the matrix using projectors.
         """
         assert n_qubits <= 32, 'cannot decompose matrices above 32 qubits'
 
@@ -283,6 +353,14 @@ class PauliwordOp:
         - projector
 
         Scales as O(M*2^N) where M the number of nonzero elements in the matrix.
+
+        Args:
+            matrix (Union[np.array, csr_matrix]): The matrix to construct the PauliwordOp from.
+            operator_basis (PauliwordOp, optional): The operator basis to use for decomposition. Defaults to None.
+            strategy (str, optional): The decomposition strategy. Options are 'full_basis' and 'projector'. Defaults to 'projector'.
+
+        Returns:
+            PauliwordOp: A new PauliwordOp object representing the matrix.
         """
         if isinstance(matrix, np.matrix):
             # summing over numpy matrices does not function correctly
@@ -346,6 +424,13 @@ class PauliwordOp:
         ) -> "PauliwordOp":
         """
         Sort the terms either by magnitude, weight X, Y or Z
+
+        Args:
+            by (str, optional): The criterion for sorting. Options are 'magnitude', 'weight', 'support', 'X', 'Y', 'Z'. Defaults to 'magnitude'.
+            key (str, optional): The sorting order. Options are 'increasing' and 'decreasing'. Defaults to 'decreasing'.
+
+        Returns:
+            PauliwordOp: A new PauliwordOp object with sorted terms.    
         """
         if by == 'magnitude':
             sort_order = np.argsort(-abs(self.coeff_vec))
@@ -372,9 +457,17 @@ class PauliwordOp:
         return PauliwordOp(self.symp_matrix[sort_order], self.coeff_vec[sort_order])
 
     def reindex(self, qubit_map: Union[List[int], Dict[int, int]]):
-        """ Re-index qubit labels
+        """ 
+        Re-index qubit labels
         For example, can specify a dictionary {0:2, 2:3, 3:0} mapping qubits 
         to their new positions or a list [2,3,0] will achieve the same result.
+
+        Args:
+            qubit_map (Union[List[int], Dict[int, int]]): A mapping of qubit indices to their new positions. 
+                It can be specified as a list [2, 3, 0] or a dictionary {0: 2, 2: 3, 3: 0}.
+
+        Returns:
+            PauliwordOp: A new PauliwordOp object with re-indexed qubit labels.
         """
         if isinstance(qubit_map, list):
             old_indices, new_indices = sorted(qubit_map), qubit_map
@@ -397,7 +490,8 @@ class PauliwordOp:
             generators: "PauliwordOp",
             override_independence_check: bool = False
         ) -> np.array:
-        """ Simultaneously reconstruct every operator term in the supplied basis.
+        """ 
+        Simultaneously reconstruct every operator term in the supplied basis.
         With B and M the symplectic form of the supplied basis and the internal 
         Pauli operator, respectively, we perform columnwise Gaussian elimination 
         to yield the matrix
@@ -414,6 +508,13 @@ class PauliwordOp:
 
         Since we only need to reduce columns, the algorithm scales with the number of
         qubits N, not the number of terms M, and is therefore at worst O(N^2).
+
+        Args:
+            generators (PauliwordOp): The basis operators for reconstruction.
+            override_independence_check (bool): Whether to override the algebraic independence check of the generators.
+
+        Returns:
+            Tuple[np.array, np.array]: A tuple containing the reconstruction matrix and a mask indicating which terms were successfully reconstructed.
         """
         if not override_independence_check:
             assert check_independent(generators), 'Supplied generators are algebraically dependent'
@@ -425,8 +526,15 @@ class PauliwordOp:
         return op_reconstruction.astype(int), mask_successfully_reconstructed
 
     def jordan_generator_reconstruction(self, generators: "PauliwordOp"):
-        """ Reconstruct this PauliwordOp under the Jordan product PQ = {P,Q}/2
+        """ 
+        Reconstruct this PauliwordOp under the Jordan product PQ = {P,Q}/2
         with respect to the supplied generators
+
+        Args:
+            generators (PauliwordOp): The basis operators for reconstruction.
+
+        Returns:
+            Tuple[np.array, np.array]: A tuple containing the reconstruction matrix and a mask indicating which terms were successfully reconstructed.
         """
         assert check_jordan_independent(generators), 'The non-symmetry elements do not pairwise anticommute.'
 
@@ -473,7 +581,14 @@ class PauliwordOp:
     def cleanup(self, 
             zero_threshold:float=1e-15
         ) -> "PauliwordOp":
-        """ Apply symplectic_cleanup and delete terms with negligible coefficients
+        """ 
+        Apply symplectic_cleanup and delete terms with negligible coefficients.
+
+        Args:
+            zero_threshold (float): Threshold below which coefficients are considered negligible.
+
+        Returns:
+            PauliwordOp: A new PauliwordOp object after cleanup.
         """
         if self.n_qubits == 0:
             return PauliwordOp([], [np.sum(self.coeff_vec)])
@@ -489,9 +604,16 @@ class PauliwordOp:
     def __eq__(self,
             Pword: "PauliwordOp"
         ) -> bool:
-        """ In theory should use logical XNOR to check symplectic matrix match, however
+        """ 
+        In theory should use logical XNOR to check symplectic matrix match, however
         can use standard logical XOR and look for False indices instead (implementation
         skips an additional NOT operation)
+
+        Args:
+            Pword (PauliwordOp): The PauliwordOp object to compare with.
+
+        Returns:
+            bool: True if the two PauliwordOp objects are equal, False otherwise.
         """
         check_1 = self.cleanup()
         check_2 = Pword.cleanup()
@@ -507,7 +629,12 @@ class PauliwordOp:
             # return eq_flag
 
     def __hash__(self) -> int:
-        """ build unique hash from dictionary of PauliwordOp"""
+        """ 
+        Build unique hash from dictionary of PauliwordOp.
+
+        Returns:
+            int: The hash value of the PauliwordOp object.
+        """
 
         self.cleanup()  # self.cleanup(zero_threshold=1e-15)
 
@@ -519,7 +646,14 @@ class PauliwordOp:
     def append(self, 
             PwordOp: "PauliwordOp"
         ) -> "PauliwordOp":
-        """ Append another PauliwordOp onto this one - duplicates allowed
+        """ 
+        Append another PauliwordOp onto this one - duplicates allowed.
+
+        Args:
+            PwordOp (PauliwordOp): The PauliwordOp object to append.
+
+        Returns:
+            PauliwordOp: The new PauliwordOp object after appending.
         """
         assert (self.n_qubits == PwordOp.n_qubits), 'Pauliwords defined for different number of qubits'
         P_symp_mat_new = np.vstack((self.symp_matrix, PwordOp.symp_matrix))
@@ -529,8 +663,15 @@ class PauliwordOp:
     def __add__(self, 
             PwordOp: "PauliwordOp"
         ) -> "PauliwordOp":
-        """ Add to this PauliwordOp another PauliwordOp by stacking the
-        respective symplectic matrices and cleaning any resulting duplicates
+        """ 
+        Add to this PauliwordOp another PauliwordOp by stacking the
+        respective symplectic matrices and cleaning any resulting duplicates.
+
+        Args:
+            PwordOp (PauliwordOp): The PauliwordOp object to add.
+
+        Returns:
+            PauliwordOp: The result of adding the two PauliwordOp objects.
         """
         # cleanup run to remove duplicate rows (Pauliwords)
         return self.append(PwordOp).cleanup()
@@ -538,7 +679,14 @@ class PauliwordOp:
     def __radd__(self, 
             add_obj: Union[int, "PauliwordOp"]
         ) -> "PauliwordOp":
-        """ Allows use of sum() over a list of PauliwordOps
+        """ 
+        Allows use of sum() over a list of PauliwordOps.
+
+        Args:
+            add_obj (Union[int, PauliwordOp]): The object to add to this PauliwordOp.
+
+        Returns:
+            PauliwordOp: The result of adding the object to this PauliwordOp.
         """
         if add_obj == 0:
             return self
@@ -548,8 +696,15 @@ class PauliwordOp:
     def __sub__(self,
             PwordOp: "PauliwordOp"
         ) -> "PauliwordOp":
-        """ Subtract from this PauliwordOp another PauliwordOp 
-        by negating the coefficients and summing
+        """ 
+        Subtract from this PauliwordOp another PauliwordOp 
+        by negating the coefficients and summing.
+
+        Args:
+            PwordOp (PauliwordOp): The PauliwordOp object to subtract.
+
+        Returns:
+            PauliwordOp: The result of subtracting the PauliwordOp object from this PauliwordOp object.
         """     
         op_copy = PwordOp.copy()
         op_copy.coeff_vec*=-1
@@ -560,7 +715,13 @@ class PauliwordOp:
             const: complex
         ) -> "PauliwordOp":
         """
-        Multiply the PauliwordOp by a complex coefficient
+        Multiply the PauliwordOp by a complex coefficient.
+
+        Args:
+            const (complex): The complex constant to multiply by.
+
+        Returns:
+            PauliwordOp: The result of multiplying the PauliwordOp by the constant.
         """
         return PauliwordOp(self.symp_matrix, self.coeff_vec*const)
 
@@ -569,9 +730,18 @@ class PauliwordOp:
             coeff: complex, 
             Y_count_in: np.array
         ) -> Tuple[np.array, np.array]:
-        """ performs Pauli multiplication with phases at the level of the symplectic 
+        """ 
+        Performs Pauli multiplication with phases at the level of the symplectic 
         matrices to avoid superfluous PauliwordOp initializations. The phase compensation 
         is implemented as per https://doi.org/10.1103/PhysRevA.68.042318.
+
+        Args:
+            symp_vec (np.array): The symplectic vector representing the Pauli operator to be multiplied with.
+            coeff (complex): The complex coefficient of the Pauli operator.
+            Y_count_in (np.array): The Y-counts of the input Pauli operator.
+
+        Returns:
+            Tuple[np.array, np.array]: The resulting symplectic vector and coefficient vector after multiplication.
         """
         # phaseless multiplication is binary addition in symplectic representation
         phaseless_prod = np.bitwise_xor(self.symp_matrix, symp_vec)
@@ -589,7 +759,15 @@ class PauliwordOp:
             PwordOp: Union["PauliwordOp", "QuantumState", complex],
             zero_threshold: float = 1e-15
         ) -> "PauliwordOp":
-        """ Right-multiplication of this PauliwordOp by another PauliwordOp or QuantumState ket.
+        """ 
+        Right-multiplication of this PauliwordOp by another PauliwordOp or QuantumState ket.
+
+        Args:
+            PwordOp (Union["PauliwordOp", "QuantumState", complex]): The operator or ket to multiply by.
+            zero_threshold (float): The threshold below which coefficients are considered negligible.
+
+        Returns:
+            PauliwordOp: The resulting PauliwordOp after multiplication.
         """
         assert (self.n_qubits == PwordOp.n_qubits), 'PauliwordOps defined for different number of qubits'
 
@@ -615,8 +793,15 @@ class PauliwordOp:
         return pauli_mult_out
     
     def expval(self, psi: "QuantumState") -> complex:
-        """ Efficient (linear) expectation value calculation using projectors
+        """ 
+        Efficient (linear) expectation value calculation using projectors
         See single_term_expval function below for further details.
+
+        Args:
+            psi (QuantumState): The quantum state for which to calculate the expectation value.
+
+        Returns:
+            complex: The expectation value.
         """
         if self.n_terms > 1:
             # parallelize if number of terms greater than one
@@ -631,7 +816,15 @@ class PauliwordOp:
             mul_obj: Union["PauliwordOp", "QuantumState", complex],
             zero_threshold: float = 1e-15
         ) -> "PauliwordOp":
-        """ Right-multiplication of this PauliwordOp by another PauliwordOp or QuantumState ket.
+        """ 
+        Right-multiplication of this PauliwordOp by another PauliwordOp or QuantumState ket.
+
+        Args:
+            mul_obj (Union["PauliwordOp", "QuantumState", complex]): The object to multiply with.
+            zero_threshold (float, optional): Threshold for cleaning up resulting PauliwordOp. Defaults to 1e-15.
+
+        Returns:
+            PauliwordOp: The result of the multiplication.
         """
         if isinstance(mul_obj, Number):
             return self.multiply_by_constant(mul_obj)
@@ -662,13 +855,29 @@ class PauliwordOp:
     def __imul__(self, 
             PwordOp: "PauliwordOp"
         ) -> "PauliwordOp":
-        """ in-place multiplication behaviour
+        """ 
+        In-place multiplication behaviour.
+
+        Args:
+            PwordOp (PauliwordOp): The `PauliwordOp` object to right-multiply with.
+
+        Returns:
+            PauliwordOp: The result of the in-place multiplication.
         """
         return self.__mul__(PwordOp)
 
     def __pow__(self, 
             exponent:int
         ) -> "PauliwordOp":
+        """
+        Exponentiation behavior.
+
+        Args:
+            exponent (int): The exponent to raise the `PauliwordOp` to.
+
+        Returns:
+            PauliwordOp: The result of the exponentiation.
+        """
         assert(isinstance(exponent, int)), 'the exponent is not an integer'
         if exponent == 0:
             return PauliwordOp.from_list(['I'*self.n_qubits],[1])
@@ -679,8 +888,15 @@ class PauliwordOp:
     def __getitem__(self, 
             key: Union[slice, int]
         ) -> "PauliwordOp":
-        """ Makes the PauliwordOp subscriptable - returns a PauliwordOp constructed
-        from the indexed row and coefficient from the symplectic matrix 
+        """ 
+        Makes the PauliwordOp subscriptable - returns a PauliwordOp constructed
+        from the indexed row and coefficient from the symplectic matrix .
+
+        Args:
+            key (Union[slice, int]): The index or slice to select the rows.
+
+        Returns:
+            PauliwordOp: A new PauliwordOp object constructed from the selected rows and coefficients.
         """
         if isinstance(key, int):
             if key<0:
@@ -705,7 +921,11 @@ class PauliwordOp:
         return PauliwordOp(symp_items, coeff_items)
 
     def __iter__(self):
-        """ Makes a PauliwordOp instance iterable
+        """ 
+        Makes a PauliwordOp instance iterable.
+
+        Returns:
+            Iterator: An iterator that generates each term of the PauliwordOp.
         """
         return iter([self[i] for i in range(self.n_terms)])
 
@@ -723,6 +943,12 @@ class PauliwordOp:
                 [ True,  True,  True],
                 [ True, False,  True]]
                 )
+
+        Args:
+            PwordOp (PauliwordOp): The PauliwordOp to check for term-wise commutation.
+
+        Returns:
+            np.array: A Boolean array indicating the term-wise commutation.
         """
         assert (self.n_qubits == PwordOp.n_qubits), 'Pauliwords defined for different number of qubits'
         Omega_PwordOp_symp = np.hstack((PwordOp.Z_block,  PwordOp.X_block)).astype(int)
@@ -731,18 +957,29 @@ class PauliwordOp:
     def anticommutes_termwise(self,
             PwordOp: "PauliwordOp"
         ) -> np.array:
+        """
+        Args:
+            PwordOp (PauliwordOp): The PauliwordOp to check for term-wise anticommutation.
+
+        Returns:
+            np.array: A Boolean array indicating the term-wise anticommutation.
+        """
         return ~self.commutes_termwise(PwordOp)
 
     def qubitwise_commutes_termwise(self,
             PwordOp: "PauliwordOp"
         ) -> np.array:
-        """ Given the symplectic representation of a single Pauli operator,
+        """ 
+        Given the symplectic representation of a single Pauli operator,
         determines which operator terms of the internal PauliwordOp qubitwise commute
+
+        Args:
+            PwordOp (PauliwordOp): The PauliwordOp to check for qubitwise term-wise commutation.
 
         Returns:  
             QWC_matrix (np.array): 
-                an array whose elements are True if the corresponding term
-                qubitwise commutes with the input PwordOp
+                An array whose elements are True if the corresponding term
+                qubitwise commutes with the input PwordOp.
         """
         QWC_matrix = []
         for X_term, Z_term in zip(PwordOp.X_block, PwordOp.Z_block):
@@ -758,41 +995,74 @@ class PauliwordOp:
     def commutator(self, 
             PwordOp: "PauliwordOp"
         ) -> "PauliwordOp":
-        """ Computes the commutator [A, B] = AB - BA
+        """ 
+        Computes the commutator [A, B] = AB - BA.
+
+        Args:
+            PwordOp (PauliwordOp): The PauliwordOp to compute the commutator with.
+
+        Returns:
+            PauliwordOp: The commutator [A, B] = AB - BA.
         """
         return self * PwordOp - PwordOp * self
 
     def anticommutator(self, 
             PwordOp: "PauliwordOp"
         ) -> "PauliwordOp":
-        """ Computes the anticommutator {A, B} = AB + BA
+        """ 
+        Computes the anticommutator {A, B} = AB + BA.
+
+        Args:
+            PwordOp (PauliwordOp): The PauliwordOp to compute the anticommutator with.
+
+        Returns:
+            PauliwordOp: The anticommutator {A, B} = AB + BA.
         """
         return self * PwordOp + PwordOp * self
 
     def commutes(self, 
             PwordOp: "PauliwordOp"
         ) -> bool:
-        """ Checks if every term of self commutes with every term of PwordOp
+        """ 
+        Checks if every term of self commutes with every term of PwordOp.
+
+        Args:
+            PwordOp (PauliwordOp): The PauliwordOp to check for commutation.
+
+        Returns:
+            bool: True if all terms commute, False otherwise.
         """
         return self.commutator(PwordOp).n_terms == 0
     
     @cached_property
     def adjacency_matrix(self) -> np.array:
-        """ Checks which terms of self commute within itself
+        """ 
+        Checks which terms of self commute within itself.
+
+        Returns:
+            np.array: Adjacency matrix.
         """
         return self.commutes_termwise(self)
 
     @cached_property
     def adjacency_matrix_qwc(self) -> np.array:
-        """ Checks which terms of self qubitwise commute within itself
+        """ 
+        Checks which terms of self qubitwise commute within itself.
+
+        Returns:
+            np.array: Adjacency matrix.
         """
         return self.qubitwise_commutes_termwise(self)
 
     @cached_property
     def is_noncontextual(self) -> bool:
-        """ Returns True if the operator is noncontextual, False if contextual
+        """ 
+        Returns True if the operator is noncontextual, False if contextual
         Scales as O(N^2), compared with the O(N^3) algorithm of https://doi.org/10.1103/PhysRevLett.123.200501
         Constructing the adjacency matrix is by far the most expensive part - very fast once that has been built.
+
+        Returns:
+            bool: True if the operator is noncontextual, False if contextual.
         """
         return check_adjmat_noncontextual(self.adjacency_matrix)
 
@@ -810,6 +1080,13 @@ class PauliwordOp:
         
         <!> Please note the definition of the angle in R(t)...
             different implementations could be out by a factor of 2!
+
+        Args:
+            Pword (PauliwordOp): The Pauliword to rotate by.
+            angle (float): The rotation angle in radians. If None, a Clifford rotation (angle=pi/2) is assumed.
+
+        Returns:
+            PauliwordOp: The rotated operator.
         """
         assert(Pword.n_terms==1), 'Only rotation by single Pauliword allowed here'
         if Pword.coeff_vec[0] != 1:
@@ -852,7 +1129,14 @@ class PauliwordOp:
         either as strings or in the symplectic representation. This method does not allow coefficients 
         to be specified as rotation in this setting is ill-defined.
 
-        If no angles are given then rotations are assumed to be pi/2 (Clifford)
+        If no angles are given then rotations are assumed to be pi/2 (Clifford).
+
+        Args:
+            rotations (List[Tuple[PauliwordOp, float]]): A list of tuples, where each tuple contains a Pauliword
+                to rotate by and the rotation angle in radians. If no angle is given, a Clifford rotation (angle=pi/2) is assumed.
+
+        Returns:
+            PauliwordOp: The operator after performing the rotations.
         """
         op_copy = self.copy()
         for pauli_rotation, angle in rotations:
@@ -860,7 +1144,14 @@ class PauliwordOp:
         return op_copy
 
     def tensor(self, right_op: "PauliwordOp") -> "PauliwordOp":
-        """ Tensor current Pauli operator with another on the right (cannot interlace currently)
+        """ 
+        Tensor current Pauli operator with another on the right (cannot interlace currently).
+
+        Args:
+            right_op (PauliwordOp): The Pauli operator to tensor with.
+
+        Returns:
+            PauliwordOp: The resulting Pauli operator after the tensor product.
         """
         identity_block_right = np.zeros([right_op.n_terms, self.n_qubits]).astype(int)
         identity_block_left  = np.zeros([self.n_terms,  right_op.n_qubits]).astype(int)
@@ -873,8 +1164,15 @@ class PauliwordOp:
     def get_graph(self, 
             edge_relation = 'C'
         ) -> nx.graph:
-        """ Build a graph based on edge relation C (commuting), 
+        """ 
+        Build a graph based on edge relation C (commuting), 
         AC (anticommuting) or QWC (qubitwise commuting).
+
+        Args:
+            edge_relation (str): The edge relation to consider. Options are 'C' for commuting, 'AC' for anticommuting, and 'QWC' for qubitwise commuting. Defaults to 'C'.
+
+        Returns:
+            nx.Graph: The graph representing the edge relation.
         """
         # build the adjacency matrix for the chosen edge relation
         if edge_relation == 'AC':
@@ -893,7 +1191,14 @@ class PauliwordOp:
     def largest_clique(self,
             edge_relation='C'
         ) -> "PauliwordOp":
-        """ Return the largest clique w.r.t. the specified edge relation
+        """ 
+        Return the largest clique w.r.t. the specified edge relation.
+
+        Args:
+            edge_relation (str): The edge relation to consider. Options are 'C' for commuting, 'AC' for anticommuting, and 'QWC' for qubitwise commuting. Defaults to 'C'.
+
+        Returns:
+            PauliwordOp: The PauliwordOp representing the largest clique.
         """
         # build graph
         graph = self.get_graph(edge_relation=edge_relation)
@@ -905,7 +1210,8 @@ class PauliwordOp:
             strategy='largest_first',
             colouring_interchange=False
         ) -> Dict[int, "PauliwordOp"]:
-        """ Perform a graph colouring to identify a clique partition
+        """ 
+        Perform a graph colouring to identify a clique partition.
 
         ------------------------
         | colouring strategies |
@@ -925,6 +1231,36 @@ class PauliwordOp:
         ------------------------
         'sorted_insertion' https://quantum-journal.org/papers/q-2021-01-20-385/pdf/
 
+        Args:
+            edge_relation (str, optional): The edge relation used for building the graph. 
+                Must be one of the following:
+                - 'C': Commuting relation.
+                - 'AC': Anticommuting relation.
+                - 'QWC': Qubitwise commuting relation.
+                Defaults to 'C'.
+
+            strategy (str, optional): The coloring strategy to be used. Must be one of the following:
+                - 'largest_first': Nodes are colored by the number of their colored neighbors in decreasing order.
+                - 'random_sequential': Nodes are colored in a random order.
+                - 'smallest_last': Nodes are colored starting from the smallest degree.
+                - 'independent_set': Independent set coloring strategy.
+                - 'connected_sequential_bfs': Nodes are colored in a connected order using BFS.
+                - 'connected_sequential_dfs': Nodes are colored in a connected order using DFS.
+                - 'connected_sequential': Alias for 'connected_sequential_bfs'.
+                - 'saturation_largest_first': Nodes are colored by their saturation degree in decreasing order.
+                - 'DSATUR': Alias for 'saturation_largest_first'.
+                Defaults to 'largest_first'.
+
+            colouring_interchange (bool, optional): Specifies whether to use interchange optimization 
+                during coloring. This can improve the quality of the coloring but may take more time.
+                Defaults to False.
+
+        Returns:
+            Dict[int, "PauliwordOp"]: A dictionary where the keys represent the clique index and 
+            the values represent the PauliwordOp objects corresponding to each clique.
+
+        Raises:
+            TypeError: If the edge_relation argument is not one of 'C', 'AC', or 'QWC'.
         """
         if strategy == 'sorted_insertion':
             ### not a graph approach
@@ -970,7 +1306,7 @@ class PauliwordOp:
     def dagger(self) -> "PauliwordOp":
         """
         Returns:
-            Pword_conj (PauliwordOp): The Hermitian conjugated operator
+            Pword_conj (PauliwordOp): The Hermitian conjugated operator.
         """
         Pword_conj = PauliwordOp(
             symp_matrix = self.symp_matrix, 
@@ -980,7 +1316,11 @@ class PauliwordOp:
 
     @cached_property
     def to_openfermion(self) -> QubitOperator:
-        """ convert to OpenFermion Pauli operator representation
+        """ 
+        Convert to OpenFermion Pauli operator representation.
+
+        Returns:
+            QubitOperator: The QubitOperator representation of the PauliwordOp.
         """
         pauli_terms = []
         for symp_vec, coeff in zip(self.symp_matrix, self.coeff_vec):
@@ -995,7 +1335,11 @@ class PauliwordOp:
 
     @cached_property
     def to_qiskit(self) -> ibm_PauliSumOp:
-        """ convert to Qiskit Pauli operator representation
+        """ 
+        Convert to Qiskit Pauli operator representation.
+
+        Returns:
+            PauliSumOp: The PauliSumOp representation of the PauliwordOp.
         """
         return ibm_PauliSumOp.from_list(self.to_dictionary.items())
 
@@ -1004,6 +1348,9 @@ class PauliwordOp:
         """
         Method for converting the operator from the symplectic representation 
         to a dictionary of the form {P_string:coeff, ...}
+
+        Returns:
+            dict: The dictionary representation of the operator in the form {P_string: coeff, ...}.
         """
         # clean the operator since duplicated terms will be overwritten in the conversion to a dictionary
         op_to_convert = self.cleanup()
@@ -1013,7 +1360,11 @@ class PauliwordOp:
 
     @cached_property
     def to_dataframe(self) -> pd.DataFrame:
-        """ Convert operator to pd.DataFrame for easy conversion to LaTeX
+        """ 
+        Convert operator to pd.DataFrame for easy conversion to LaTeX.
+
+        Returns:
+            pd.DataFrame: The DataFrame representation of the operator.
         """
         paulis = list(self.to_dictionary.keys())
         DF_out = pd.DataFrame.from_dict({
@@ -1034,7 +1385,7 @@ class PauliwordOp:
         one nonzero entry in each row and column
 
         Returns:
-            sparse_matrix (csr_matrix): sparse matrix of PauliOp
+            sparse_matrix (csr_matrix): Sparse matrix of PauliOp.
         """
         if self.n_qubits == 0:
             return csr_matrix(self.coeff_vec)
@@ -1116,8 +1467,6 @@ class PauliwordOp:
 
         = ∑_{a}∑_{i=j} (-1)^{C_{ia}} (ci ca ci^{*}) Pa
          + ∑_{a}∑_{i}∑_{j>i} (ci ca cj^{*} + (-1)^{C_{ia}+A_{ij}+C_{ja}}(cj ca ci^{*})) Pi  Pa Pj
-
-
         """
 
         # see from symmer.operators.anticommuting_op import conjugate_Pop_with_R
@@ -1125,7 +1474,8 @@ class PauliwordOp:
 
 
 class QuantumState:
-    """ Class to represent quantum states.
+    """ 
+    Class to represent quantum states.
     
     This is achieved by identifying the state with a 
     state_op (PauliwordOp), namely |0> --> Z, |1> --> X. 
@@ -1138,7 +1488,10 @@ class QuantumState:
     This ensures correct phases when multiplying the quantum state by a PauliwordOp.
 
     QuantumState is defined in base.py to avoid circular imports since multiplication
-    behaviour is defined between QuantumState and PauliwordOp
+    behaviour is defined between QuantumState and PauliwordOp.
+
+     Attributes:
+        sigfig (int): The number of significant figures for printing.
     """
     sigfig = 3 # specifies the number of significant figures for printing
     
@@ -1147,11 +1500,17 @@ class QuantumState:
             coeff_vector: Union[List[complex], np.array] = None,
             vec_type: str = 'ket'
         ) -> None:
-        """ The state is not normalized by default, since this would result
+        """ 
+        The state is not normalized by default, since this would result
         in incorrect behaviour when perfoming non-unitary multiplications,
         e.g. for evaluating expectation values of Hamiltonians. However, if
         one wishes to normalize the state, it is stored as a cached propoerty
         as QuantumState.normalize.
+
+        Args:
+            state_matrix (Union[List[List[int]], np.array]): The state matrix representing the quantum state.
+            coeff_vector (Union[List[complex], np.array], optional): The coefficient vector for the quantum state. Defaults to None.
+            vec_type (str, optional): The type of vector representation (e.g., 'ket', 'bra'). Defaults to 'ket'.
         """
         if isinstance(state_matrix, list):
             state_matrix = np.array(state_matrix)
@@ -1173,7 +1532,10 @@ class QuantumState:
 
     def copy(self) -> "QuantumState":
         """ 
-        Create a carbon copy of the class instance
+        Create a carbon copy of the class instance.
+
+        Returns:
+            QuantumState: A copy of the class instance.
         """
         return deepcopy(self)
 
@@ -1190,7 +1552,6 @@ class QuantumState:
 
         Returns:
             qstate_random (QuantumState): Haar random quantum state
-
         """
         if vec_type=='ket':
             haar_vec = (unitary_group.rvs(2**n_qubits)[:,0]).reshape([-1, 1])
@@ -1204,7 +1565,16 @@ class QuantumState:
     
     @classmethod
     def random(cls, num_qubits: int, num_terms: int, vec_type: str='ket') -> "QuantumState":
-        """ Generates a random normalized QuantumState, but not from Haar distribution
+        """ 
+        Generates a random normalized QuantumState, but not from Haar distribution.
+
+        Args:
+            num_qubits (int): The number of qubits.
+            num_terms (int): The number of terms.
+            vec_type (str, optional): The vector type. Defaults to 'ket'.
+
+        Returns:
+            QuantumState: A random normalized QuantumState instance.
         """
         # random binary array with N columns, M rows
         random_state = np.random.randint(0,2,(num_terms,num_qubits))
@@ -1228,7 +1598,6 @@ class QuantumState:
 
         Returns:
             q_zero_state (QuantumState): zero ket or bra quantum state
-
         """
         binary_zero = np.zeros(n_qubits).reshape(1,-1)
         q_zero_state = QuantumState(binary_zero, coeff_vector=np.array([1]), vec_type=vec_type)
@@ -1253,18 +1622,37 @@ class QuantumState:
         return out_string[:-3]
 
     def __repr__(self):
+        """
+        Returns a string representation of the QuantumState object.
+        """
         return str(self)
 
     def __eq__(self, 
             Qstate: "QuantumState"
         ) -> bool:
+        """
+        Check if the current QuantumState object is equal to another QuantumState object.
+
+        Args:
+            Qstate (QuantumState): The QuantumState object to compare with.
+
+        Returns:
+            bool: True if the QuantumState objects are equal, False otherwise.
+        """
         return self.state_op == Qstate.state_op
     
     def __add__(self, 
             Qstate: "QuantumState"
         ) -> "QuantumState":
-        """ Add to this QuantumState another QuantumState by summing 
-        the respective state_op (PauliwordOp representing the state)
+        """ 
+        Add to this QuantumState another QuantumState by summing 
+        the respective state_op (PauliwordOp representing the state).
+
+        Args:
+            Qstate (QuantumState): The QuantumState object to add.
+
+        Returns:
+            QuantumState: A new QuantumState object representing the sum of the two QuantumStates.
         """
         new_state = self.state_op + Qstate.state_op
         return QuantumState(new_state.X_block, new_state.coeff_vec)
@@ -1272,7 +1660,14 @@ class QuantumState:
     def __radd__(self, 
             add_obj: Union[int, "QuantumState"]
         ) -> "QuantumState":
-        """ Allows use of sum() over a list of PauliwordOps
+        """ 
+        Allows use of sum() over a list of PauliwordOps.
+
+        Args:
+            add_obj (Union[int, QuantumState]): The object to add.
+
+        Returns:
+            QuantumState: A new QuantumState object representing the sum.
         """
         if add_obj == 0:
             return self
@@ -1282,8 +1677,15 @@ class QuantumState:
     def __sub__(self, 
             Qstate: "QuantumState"
         ) -> "QuantumState":
-        """ Subtract from this QuantumState another QuantumState by subtracting 
-        the respective state_op (PauliwordOp representing the state)
+        """ 
+        Subtract from this QuantumState another QuantumState by subtracting 
+        the respective state_op (PauliwordOp representing the state).
+
+        Args:
+            Qstate (QuantumState): The QuantumState object to subtract.
+
+        Returns:
+            QuantumState: A new QuantumState object representing the difference.
         """
         new_state_op = self.state_op - Qstate.state_op
         return QuantumState(new_state_op.X_block, new_state_op.coeff_vec)
@@ -1292,8 +1694,11 @@ class QuantumState:
         mul_obj: Union["QuantumState", PauliwordOp]
         ) -> Union["QuantumState", complex]:
         """
-        Right multiplication of a bra QuantumState by either a ket QuantumState or PauliwordOp
+        Right multiplication of a bra QuantumState by either a ket QuantumState or PauliwordOp.
         
+        Args:
+            mul_obj (Union["QuantumState", PauliwordOp]): The object to multiply with.
+
         Returns:
             - inner_product (complex): when mul_obj is a ket state
             - new_bra_state (QuantumState): when mul_obj is a PauliwordOp
@@ -1337,8 +1742,15 @@ class QuantumState:
             raise ValueError('Trying to multiply QuantumState by unrecognised object - must be another Quantum state or PauliwordOp')   
     
     def __getitem__(self, key: Union[slice, int]) -> "QuantumState":
-        """ Makes the QuantumState subscriptable - returns a QuantumState 
-        constructed from the indexed rows and coefficients of the state matrix 
+        """ 
+        Makes the QuantumState subscriptable - returns a QuantumState 
+        constructed from the indexed rows and coefficients of the state matrix.
+
+        Args:
+            key (Union[slice, int]): The index or slice object used for subscripting.
+
+        Returns:
+            QuantumState: The QuantumState object constructed from the indexed rows and coefficients.
         """
         if isinstance(key, int):
             if key<0:
@@ -1359,12 +1771,23 @@ class QuantumState:
         return QuantumState(state_items, coeff_items)
 
     def __iter__(self):
-        """ Makes a QuantumState instance iterable
+        """ 
+        Makes a QuantumState instance iterable.
+
+        Returns:
+            iter: An iterator that generates elements by iterating over the QuantumState object.
         """
         return iter([self[i] for i in range(self.n_terms)])
 
     def cleanup(self, zero_threshold=1e-15) -> "QuantumState":
-        """ Combines duplicate basis states, summing their coefficients
+        """ 
+        Combines duplicate basis states, summing their coefficients.
+
+        Args:
+            zero_threshold (float): Threshold below which coefficients are considered zero.
+
+        Returns:
+            QuantumState: A new QuantumState object with combined duplicate basis states.
         """
         clean_state_op = self.state_op.cleanup(zero_threshold=zero_threshold)
         return QuantumState(
@@ -1375,7 +1798,14 @@ class QuantumState:
 
     def sort(self, by='decreasing', key='magnitude') -> "QuantumState":
         """
-        Sort the terms by some key, either magnitude, weight X, Y or Z
+        Sort the terms by some key, either magnitude, weight X, Y or Z.
+
+        Args:
+            by (str): Sort order, either 'increasing' or 'decreasing'.
+            key (str): Sort key, either 'magnitude' or 'support'.
+
+        Returns:
+            QuantumState: A new QuantumState object with sorted terms.
         """
         if key=='magnitude':
             sort_order = np.argsort(-abs(self.state_op.coeff_vec))
@@ -1390,9 +1820,17 @@ class QuantumState:
         return QuantumState(self.state_matrix[sort_order], self.state_op.coeff_vec[sort_order])
 
     def reindex(self, qubit_map: Union[List[int], Dict[int, int]]):
-        """ Re-index qubit labels
+        """ 
+        Re-index qubit labels.
         For example, can specify a dictionary {0:2, 2:3, 3:0} mapping qubits 
         to their new positions or a list [2,3,0] will achieve the same result.
+
+        Args:
+            qubit_map (Union[List[int], Dict[int, int]]): A mapping of qubits to their new positions. It can be specified
+                as a list [2, 3, 0] or a dictionary {0: 2, 2: 3, 3: 0}.
+
+        Returns:
+            QuantumState: A new QuantumState object with re-indexed qubit labels.
         """
         if isinstance(qubit_map, list):
             old_indices, new_indices = sorted(qubit_map), qubit_map
@@ -1410,7 +1848,14 @@ class QuantumState:
         return QuantumState(new_state_matrix, self.state_op.coeff_vec, vec_type=self.vec_type)
 
     def sectors_present(self, symmetry):
-        """ return the sectors present within the QuantumState w.r.t. a IndependentOp
+        """ 
+        Return the sectors present within the QuantumState w.r.t. a IndependentOp.
+
+        Args:
+            symmetry (IndependentOp): The IndependentOp object representing the symmetry.
+
+        Returns:
+            numpy.ndarray: An array representing the sectors present within the QuantumState.
         """
         symmetry_copy = symmetry.copy()
         symmetry_copy.coeff_vec = np.ones(symmetry.n_terms)
@@ -1419,22 +1864,24 @@ class QuantumState:
 
     @cached_property
     def normalize(self):
-        """ Normalize a state by dividing through its norm.
+        """ 
+        Normalize a state by dividing through its norm.
 
         Returns:
-            self (QuantumState)
+            self (QuantumState): The normalized QuantumState.
         """
         coeff_vector = self.state_op.coeff_vec/np.linalg.norm(self.state_op.coeff_vec)
         return QuantumState(self.state_matrix, coeff_vector, vec_type=self.vec_type)
 
     @cached_property
     def normalize_counts(self):
-        """ Normalize a state by dividing through by the sum of coefficients and taking its square 
+        """ 
+        Normalize a state by dividing through by the sum of coefficients and taking its square 
         root. This normalization is faithful to the probability distribution one might obtain from
         quantum circuit sampling. A subtle difference, but important!
 
         Returns:
-            self (QuantumState)
+            self (QuantumState): The normalized QuantumState.
         """
         coeff_vector = np.sqrt(self.state_op.coeff_vec/np.sum(self.state_op.coeff_vec))
         return QuantumState(self.state_matrix, coeff_vector, vec_type=self.vec_type)
@@ -1443,7 +1890,7 @@ class QuantumState:
     def dagger(self) -> "QuantumState":
         """
         Returns:
-            conj_state (QuantumState): The Hermitian conjugated state i.e. bra -> ket, ket -> bra
+            conj_state (QuantumState): The Hermitian conjugated state i.e. bra -> ket, ket -> bra.
         """
         if self.vec_type == 'ket':
             new_type = 'bra'
@@ -1460,7 +1907,7 @@ class QuantumState:
     def to_sparse_matrix(self):
         """
         Returns:
-            sparse_Qstate (csr_matrix): sparse matrix representation of the statevector
+            sparse_Qstate (csr_matrix): sparse matrix representation of the statevector.
         """
         # nonzero_indices = [int(''.join([str(i) for i in row]),2) for row in self.state_matrix]
         # if self.n_qubits<64:
@@ -1481,10 +1928,10 @@ class QuantumState:
 
     def _is_normalized(self) -> bool:
         """
-        check if state is normalized
+        Check if state is normalized.
 
         Returns:
-            True or False depending on if state is normalized
+            bool: True or False depending on if state is normalized.
 
         """
 
@@ -1523,7 +1970,9 @@ class QuantumState:
 
     @cached_property
     def to_dictionary(self) -> Dict[str, complex]:
-        """ Return the QuantumState as a dictionary
+        """ 
+        Returns:
+            dict: The QuantumState represented as a dictionary.
         """
         state_to_convert = self.cleanup()
         state_dict = dict(
@@ -1538,8 +1987,15 @@ class QuantumState:
     def from_dictionary(cls, 
             state_dict: Dict[str, Union[complex, Tuple[float, float]]]
         ) -> "QuantumState":
-        """ Initialize a QuantumState from a dictionary of the form {'1101':a, '0110':b, '1010':c, ...}. This is useful for
+        """ 
+        Initialize a QuantumState from a dictionary of the form {'1101':a, '0110':b, '1010':c, ...}. This is useful for
         converting the measurement output of a quantum circuit to a QuantumState object for further manipulation/bootstrapping.
+
+        Args:
+            state_dict (Dict[str, Union[complex, Tuple[float, float]]]): The dictionary representation of the QuantumState.
+
+        Returns:
+            QuantumState: The initialized QuantumState object.
         """
         bin_strings, coeff_vector = zip(*state_dict.items())
 
@@ -1558,10 +2014,13 @@ class QuantumState:
             statevector: np.array,
             threshold: float =1e-15,
         ) -> "QuantumState":
-        """ Initialize a QubitState from a vector of 2^N elements over N qubits
+        """ 
+        Initialize a QubitState from a vector of 2^N elements over N qubits
+        
         Args:
             statevector (np.array): numpy array of quantum state (size 2^N by 1)
             threshold (float): threshold to determine zero amplitudes (absolute value)
+       
         Returns:
             Qstate (QuantumState): a QuantumState object
 
@@ -1605,7 +2064,18 @@ class QuantumState:
             binary_xlabels = False,
             dpi:int=100
         ):
+        """
+        Plot the probabilities of the quantum state.
 
+        Args:
+            logscale (bool): Whether to use a logarithmic scale for the y-axis.
+            probability_threshold (float): Threshold for considering probabilities as zero.
+            binary_xlabels (bool): Whether to use binary strings as x-axis labels.
+            dpi (int): Dots per inch of the plot.
+
+        Returns:
+            matplotlib.axes.Axes: The plot axes.
+        """
         assert self._is_normalized(), 'should only plot normalized quantum states'
 
         # clean duplicate states and set amplitdue threshold
@@ -1741,7 +2211,9 @@ def get_ij_operator(i:int, j:int, n_qubits:int,
         n_qubits (int): number of qubits
         binary_vec (optional): bool array of all bitstrings on n_qubits
         return_operator (bool): whether to return PauliWordOp or a the symplectic matrix and coeff_vec
-
+    
+    Returns:
+        Union["PauliwordOp", Tuple[np.ndarray, np.ndarray]]: Pauli operator or the symplectic matrix and coeff_vec
     """
     if n_qubits > 30:
         raise ValueError('Too many qubits, might run into memory limitations.')
@@ -1786,12 +2258,23 @@ def get_ij_operator(i:int, j:int, n_qubits:int,
 
 
 def single_term_expval(P_op: PauliwordOp, psi: QuantumState) -> float:
-    """ Expectation value calculation for a single Pauli operator given a QuantumState psi
+    """ 
+    Expectation value calculation for a single Pauli operator given a QuantumState psi
 
     Scales linearly in the number of basis states of psi, versus the quadratic cost of
     evaluating <psi|P|psi> directly, taking into consideration all of the cross-terms.
 
     Works by decomposing P = P(+) - P(-) where P(±) = (I±P)/2 projects onto the ±1-eigensapce of P. 
+
+    Args:
+        P_op (PauliwordOp): The Pauli operator for which to calculate the expectation value.
+        psi (QuantumState): The quantum state on which to calculate the expectation value.
+
+    Returns:
+        float: The expectation value of the Pauli operator.
+
+    Raises:
+        AssertionError: If the supplied Pauli operator has multiple terms.
     """
     assert P_op.n_terms == 1, 'Supplied multiple Pauli terms.'
     

--- a/symmer/operators/utils.py
+++ b/symmer/operators/utils.py
@@ -237,7 +237,8 @@ def safe_PauliwordOp_to_dict(op) -> Dict[str, Tuple[float, float]]:
     return dict_out
 
 def safe_QuantumState_to_dict(psi) -> Dict[str, Tuple[float, float]]:
-    """ Stores the real and imaginary parts of the coefficient separately in a tuple
+    """ 
+    Stores the real and imaginary parts of the coefficient separately in a tuple
 
     Args:
         op (QuantumState): Weighted linear combination of N-fold Pauli operators
@@ -255,35 +256,35 @@ def mul_symplectic(
         coeff1: complex,
         symp_vec2: np.array,
         coeff2: complex) -> Tuple[np.array, complex, int]:
-    """ performs Pauli multiplication with phases at the level of the symplectic
-         vector (1D here!). The phase compensation is implemented as per https://doi.org/10.1103/PhysRevA.68.042318.
+    """ 
+    Performs Pauli multiplication with phases at the level of the symplectic
+    vector (1D here!). The phase compensation is implemented as per https://doi.org/10.1103/PhysRevA.68.042318.
 
-        P1 * P2 is performed
+    P1 * P2 is performed
 
     Args:
         symp_vec1 (np.array) : 1D vector of left Pauli operator
         coeff1 (float): coefficient of left  Pauli operator
-        Y_count1: number of Y terms in left Pauli operator
 
         symp_vec2 (np.array) : 1D vector of right Pauli operator
         coeff2 (float): coefficient of right  Pauli operator
-        Y_count2: number of Y terms in right Pauli operator
 
     Returns:
         output_symplectic_vec (np.array): binary symplectic output (Pauli opertor out)
         coeff_vec (complex): complex coeff with correct phase
-        Y_count_out (int): number of Y terms in output
     """
     X_block1, Z_block1 = np.split(symp_vec1, 2)
     X_block2, Z_block2 = np.split(symp_vec2, 2)
 
+    # number of Y terms in left Pauli operator
     Y_count1 = np.sum(np.bitwise_and(X_block1, Z_block1), axis=0)
+    # number of Y terms in right Pauli operator
     Y_count2 = np.sum(np.bitwise_and(X_block2, Z_block2), axis=0)
 
     # phaseless multiplication is binary addition in symplectic representation
     output_symplectic_vec = np.bitwise_xor(symp_vec1, symp_vec2)
     # phase is determined by Y counts plus additional sign flip
-    Y_count_out = np.sum(np.bitwise_and(*np.split(output_symplectic_vec, 2)), axis=0)
+    Y_count_out = np.sum(np.bitwise_and(*np.split(output_symplectic_vec, 2)), axis=0) # number of Y terms in output
     # X_block of first op and Z_block of second op
     sign_change = (-1) ** (
             np.sum(np.bitwise_and(X_block1, Z_block2), axis=0) % 2
@@ -294,16 +295,31 @@ def mul_symplectic(
     return output_symplectic_vec, coeff_vec #, Y_count_out
 
 def unit_n_sphere_cartesian_coords(angles: np.array) -> np.array:
-    """ Input an array of angles of length n, returns the n+1 cartesian coordinates 
+    """ 
+    Input an array of angles of length n, returns the n+1 cartesian coordinates 
     of the corresponding unit n-sphere in (n+1)-dimensional Euclidean space.
+
+    Args:
+        angles (np.array): Array of angles of length n of the corresponding unit n-sphere in (n+1)-dimensional Euclidean space.
+
+    Returns:
+        Numpy Array of n+1 cartesian coordinates.
     """
     cartesians = [np.prod(np.sin(angles[:i]))*np.cos(angles[i]) for i in range(len(angles))]
     cartesians.append(np.prod(np.sin(angles)))
     return np.array(cartesians)
 
 def binomial_coefficient(n,k):
-    """ Calculate the binomial coefficient n choose k
-    Differs from np.math.comb as this allows non-integer n
+    """ 
+    Calculate the binomial coefficient "n choose k" or denoted as "C(n, k)," represents the number of ways to choose k objects from a set of n objects without considering their order.
+    Differs from np.math.comb as this allows non-integer n.
+
+    Args: 
+        n: Total number of objects.
+        k: Number of object to choose from a set of n objects.
+
+    Returns:
+        Binomial coefficient "n choose k".
     """
     prod = 1
     for r in range(k):
@@ -311,13 +327,27 @@ def binomial_coefficient(n,k):
     return prod
 
 def check_independent(operators):
-    """ Check if the input PauliwordOp contains algebraically dependent terms
+    """
+    Check if the input PauliwordOp contains algebraically dependent terms.
+    
+    Args:
+        operators (PauliwordOp): Operators.
+
+    Returns:
+        Returns True, if input operators contains algebraically dependent terms.
     """
     check_independent = _rref_binary(operators.symp_matrix)
     return ~np.any(np.all(~check_independent, axis=1))
 
 def check_jordan_independent(operators):
-    """ Check if the input PauliwordOp contains algebraically dependent terms
+    """ 
+    Check if the input PauliwordOp contains algebraically dependent terms.
+
+    Args:
+        operators (PauliwordOp): Operators.
+    
+    Returns:
+        Returns True, if input operators contains algebraically dependent terms.
     """
     mask_symmetries = np.all(operators.adjacency_matrix, axis=1)
     Symmetries = operators[mask_symmetries]
@@ -328,8 +358,15 @@ def check_jordan_independent(operators):
     )
 
 def check_adjmat_noncontextual(adjmat) -> bool:
-    """ Check whether the input boolean square matrix has a noncontextual structure...
+    """
+    Check whether the input boolean square matrix has a noncontextual structure...
     ... see https://doi.org/10.1103/PhysRevLett.123.200501 for details.
+
+    Args:
+        adjmat: Boolean square matrix.
+
+    Returns:
+        Returns True, if input matrix has a noncontextual structure.
     """
     # mask the terms that do not commute universally amongst the operator
     mask_non_universal = np.where(~np.all(adjmat, axis=1))[0]
@@ -345,8 +382,15 @@ def check_adjmat_noncontextual(adjmat) -> bool:
     return np.all(np.count_nonzero(unique_commutation_character, axis=0)==1)
 
 def perform_noncontextual_sweep(operator):
-    """ Given an ordered operator, sweep over its terms and append 
+    """
+    Given an ordered operator, sweep over its terms and append 
     to a list if the newly appended term maintains noncontextuality.
+
+    Args:
+        operator (PauliwordOp): Ordered operator.
+
+    Returns:
+        List of terms maintaining noncontextuality.
     """
     # initialize noncontextual operator with first element of input operator
     noncon_indices = np.array([0])
@@ -365,13 +409,12 @@ def perform_noncontextual_sweep(operator):
 
 def binary_array_to_int(bin_arr):
     """
-    function to convert an array composed of rows of binary into integars
+    Function to convert an array composed of rows of binary into integers.
 
     Args:
-        bin_arr(np.array): 2D numpy array of binary
+        bin_arr(np.array): 2D numpy array of binary.
     Returns:
-        int_arr (np.array): 1D numpy array of ints
-
+        int_arr (np.array): 1D numpy array of ints.
     """
 
     if bin_arr.shape[1] < 64:

--- a/symmer/operators/utils.py
+++ b/symmer/operators/utils.py
@@ -13,7 +13,6 @@ def symplectic_to_string(symp_vec) -> str:
 
     Returns:
         Pword_string (str): String version of symplectic array
-
     """
     n_qubits = len(symp_vec) // 2
 
@@ -36,6 +35,12 @@ def symplectic_to_string(symp_vec) -> str:
 
 def string_to_symplectic(pauli_str, n_qubits):
     """
+    Args:
+        pauli_str (str): Pauli String to be converted to symplectic array
+        n_qubits (int): Number of qubits
+
+    Returns:
+        symp_vec (array): symplectic Pauliword array
     """
     assert(len(pauli_str) == n_qubits), 'Number of qubits is incompatible with pauli string'
     assert (set(pauli_str).issubset({'I', 'X', 'Y', 'Z'})), 'pauliword must only contain X,Y,Z,I terms'
@@ -59,6 +64,12 @@ def count1_in_int_bitstring(i):
 
     https://stackoverflow.com/questions/109023/how-to-count-the-number-of-set-bits-in-a-32-bit-integer#109025
     https://web.archive.org/web/20151229003112/http://blogs.msdn.com/b/jeuge/archive/2005/06/08/hakmem-bit-count.aspx
+
+    Args:
+        i (int):  Integer
+
+    Returns:
+        Number of "1" bits in the bitstring of integer 'i'.
     """
     i = i - ((i >> 1) & 0x55555555)  # add pairs of bits
     i = (i & 0x33333333) + ((i >> 2) & 0x33333333)  # quads
@@ -77,7 +88,6 @@ def symplectic_to_sparse_matrix(symp_vec, coeff) -> sp.sparse.csr_matrix:
 
     Returns:
         sparse_matrix (csr_matrix): sparse matrix of Pauliword
-
     """
     n_qubits = len(symp_vec) // 2
 
@@ -118,8 +128,17 @@ def symplectic_cleanup(
         coeff_vec:      np.array, 
         zero_threshold: float = None
     ) -> Tuple[np.array, np.array]:
-    """ Remove duplicated rows of symplectic matrix terms, whilst summing
+    """ 
+    Remove duplicated rows of symplectic matrix terms, whilst summing
     the corresponding coefficients of the deleted rows in coeff_vec
+
+    Args:
+        symp_matrix (np.array): Symplectic matrix.
+        coeff_vec (np.array): Coefficient Vector.
+        zero_threshold (float): Zero Threshold Value. By default it is set to 'None'.
+
+    Returns: 
+        Reduced symplectic matrix and reduced coefficient vector.
     """
     # order lexicographically using a fast void view implementation...
     # this scales to large numbers of qubits more favourably than np.lexsort
@@ -146,7 +165,8 @@ def symplectic_cleanup(
     return reduced_symp_matrix, reduced_coeff_vec
 
 def random_symplectic_matrix(n_qubits,n_terms, diagonal=False, density=0.3):
-    """ Generates a random binary matrix of dimension (n_terms) x (2*n_qubits)
+    """ 
+    Generates a random binary matrix of dimension (n_terms) x (2*n_qubits)
     Specifying diagonal=True will set the left hand side (X_block) to all zeros
     """
     if diagonal:
@@ -156,8 +176,15 @@ def random_symplectic_matrix(n_qubits,n_terms, diagonal=False, density=0.3):
         return np.random.choice([True, False], size=[n_terms,2*n_qubits], p=[density, 1-density])
 
 def _rref_binary(matrix: np.array) -> np.array:
-    """ Row-reduced echelon form over the binary field (GF2) - rows are not reordered 
-    here for efficiency (not required in some use cases, e.g. symmetry identification)
+    """ 
+    Row-reduced echelon form over the binary field (GF2) - rows are not reordered 
+    here for efficiency (not required in some use cases, e.g. symmetry identification).
+
+    Args:
+        matrix(np.array): Matrix whose row-reduced echelon form over the binary field has to be found.
+
+    Returns:
+        Row-reduced echelon form over the binary field of input matrix.
     """
     rref_matrix = matrix.copy()
     # iterate over rows of array
@@ -174,7 +201,14 @@ def _rref_binary(matrix: np.array) -> np.array:
     return rref_matrix
 
 def rref_binary(matrix: np.array) -> np.array:
-    """ Full row-reduced echelon form with row reordering
+    """ 
+    Full row-reduced echelon form with row reordering.
+
+    Args:
+        matrix(np.array): Matrix whose row-reduced echelon form with row reordering has to be found.
+
+    Returns:
+        Row-reduced echelon form of input matrix with row reordering of input matrix.
     """
     reduced = _rref_binary(matrix)
     row_order, col_order = zip(
@@ -187,17 +221,39 @@ def rref_binary(matrix: np.array) -> np.array:
     return reduced[row_order]
 
 def _cref_binary(matrix: np.array) -> np.array:
-    """ Column-reduced echelon form with static columns (used in symmetry identification)
+    """ 
+    Column-reduced echelon form with static columns (used in symmetry identification).
+    
+    Args:
+        matrix(np.array): Matrix whose column-reduced echelon form with static columns has to be found.
+
+    Returns:
+        Column-reduced echelon form of input matrix with static columns.
     """
     return _rref_binary(matrix.T).T  
 
 def cref_binary(matrix: np.array) -> np.array:
-    """ Column-reduced echelon form with ordered columns (used in basis reconstruction)
+    """ 
+    Column-reduced echelon form with ordered columns (used in basis reconstruction).
+        
+    Args:
+        matrix(np.array): Matrix whose column-reduced echelon form with ordered columns has to be found.
+
+    Returns:
+        Column-reduced echelon form of input matrix with ordered columns.
     """
     return rref_binary(matrix.T).T        
 
 def QubitOperator_to_dict(op, num_qubits):
-    """ OpenFermion
+    """ 
+    OpenFermion
+
+    Args:
+        op: Qubit Operator
+        num_qubits: Number of qubiits.
+
+    Returns:
+        Dictionary format of Qubit Operator.
     """
     assert(type(op) == of.QubitOperator)
     op_dict = {}
@@ -214,7 +270,14 @@ def QubitOperator_to_dict(op, num_qubits):
     return op_dict
 
 def PauliSumOp_to_dict(op:PauliSumOp) -> dict:
-    """ Qiskit
+    """ 
+    Qiskit
+    
+    Args:
+        op (PauliSumOp): Pauli Sum Operator
+
+    Returns:
+        Dictionary format of Pauli Sum Operator.
     """
     H_dict = {}
     for P_term in op.to_pauli_op():
@@ -223,13 +286,13 @@ def PauliSumOp_to_dict(op:PauliSumOp) -> dict:
     return H_dict
 
 def safe_PauliwordOp_to_dict(op) -> Dict[str, Tuple[float, float]]:
-    """ Stores the real and imaginary parts of the coefficient separately in a tuple
+    """ 
+    Stores the real and imaginary parts of the coefficient separately in a tuple.
 
     Args:
-        op (PauliwordOp): Weighted linear combination of N-fold Pauli operators
+        op (PauliwordOp): Weighted linear combination of N-fold Pauli operators.
     Returns:
-        dict_out (dict): Dictionary of the form {pstring:(real, imag)}
-
+        dict_out (dict): Dictionary of the form {pstring:(real, imag)}.
     """
     terms, coeffs = zip(*op.to_dictionary.items())
     coeffs = [(n.real, n.imag) for n in coeffs]
@@ -238,13 +301,12 @@ def safe_PauliwordOp_to_dict(op) -> Dict[str, Tuple[float, float]]:
 
 def safe_QuantumState_to_dict(psi) -> Dict[str, Tuple[float, float]]:
     """ 
-    Stores the real and imaginary parts of the coefficient separately in a tuple
+    Stores the real and imaginary parts of the coefficient separately in a tuple.
 
     Args:
-        op (QuantumState): Weighted linear combination of N-fold Pauli operators
+        op (QuantumState): Weighted linear combination of N-fold Pauli operators.
     Returns:
-        dict_out (dict): Dictionary of the form {pstring:(real, imag)}
-
+        dict_out (dict): Dictionary of the form {pstring:(real, imag)}.
     """
     terms, coeffs = zip(*psi.to_dictionary.items())
     coeffs = [(n.real, n.imag) for n in coeffs]

--- a/symmer/projection/base.py
+++ b/symmer/projection/base.py
@@ -5,7 +5,8 @@ from symmer.evolution import trotter, Had
 from functools import reduce
 
 class S3_projection:
-    """ Base class for enabling qubit reduction techniques derived from
+    """ 
+    Base class for enabling qubit reduction techniques derived from
     the Stabilizer SubSpace (S3) projection framework, such as tapering
     and Contextual-Subspace VQE. The methods defined herein serve the 
     following purposes:
@@ -20,6 +21,9 @@ class S3_projection:
         This method wraps _perform_projection but provides the facility to insert
         auxiliary rotations (that need not be Clifford). This is used in CS-VQE
         to implement unitary partitioning where necessary. 
+
+    Attributes:
+        rotated_flag (bool): If true, operator will be rotated. By default, it is set to 'false'.
     """
     rotated_flag = False
 
@@ -27,15 +31,13 @@ class S3_projection:
                 stabilizers: IndependentOp
                 ) -> None:
         """
-        - stabilizers
-            a list of stabilizers that should be enforced, given as Pauli strings
-        - eigenvalues
-            the list of eigenvalue assignments to complement the stabilizers
-        - target_sqp
-            the target single-qubit Pauli (X or Z) that we wish to rotate onto
-        - fix_qubits
-            Manually overrides the qubit positions selected in stabilizer_rotations, 
-            although the rotation procedure can be a bit unpredictable so take care!
+        - eigenvalues: The list of eigenvalue assignments to complement the stabilizers.
+        
+        - target_sqp: The target single-qubit Pauli (X or Z) that we wish to rotate onto.
+        - fix_qubits: Manually overrides the qubit positions selected in stabilizer_rotations, although the rotation procedure can be a bit unpredictable so take care!
+
+        Args:
+        stabilizers (IndependentOp): A list of stabilizers that should be enforced, given as Pauli strings.
         """
         self.stabilizers = stabilizers
         
@@ -43,8 +45,12 @@ class S3_projection:
             operator: PauliwordOp,
             #sym_sector: Union[List[int], np.array]
         ) -> PauliwordOp:
-        """ method for projecting an operator over fixed qubit positions 
-        stabilized by single Pauli operators (obtained via Clifford operations)
+        """ 
+        Method for projecting an operator over fixed qubit positions 
+        stabilized by single Pauli operators (obtained via Clifford operations).
+
+        Args:
+            operator (PauliwordOp): Operator which has to be projected over fixed qubit positions stabilized by single Pauli operators.
         """
         assert(operator.n_qubits == self.stabilizers.n_qubits), 'The input operator does not have the same number of qubits as the stabilizers'
         assert(self.rotated_flag), 'The operator has not been rotated - intended for use with perform_projection method'
@@ -79,7 +85,8 @@ class S3_projection:
             ref_state: Union[List[int], np.array]=None,
             sector: Union[List[int], np.array]=None
         ) -> PauliwordOp:
-        """ Input a PauliwordOp and returns the reduced operator corresponding 
+        """ 
+        Input a PauliwordOp and returns the reduced operator corresponding 
         with the specified stabilizers and eigenvalues.
         
         insert_rotation allows one to include supplementary Pauli rotations

--- a/symmer/projection/base.py
+++ b/symmer/projection/base.py
@@ -37,7 +37,7 @@ class S3_projection:
         - fix_qubits: Manually overrides the qubit positions selected in stabilizer_rotations, although the rotation procedure can be a bit unpredictable so take care!
 
         Args:
-        stabilizers (IndependentOp): A list of stabilizers that should be enforced, given as Pauli strings.
+            stabilizers (IndependentOp): A list of stabilizers that should be enforced, given as Pauli strings.
         """
         self.stabilizers = stabilizers
         
@@ -98,7 +98,8 @@ class S3_projection:
 
         Args: 
             operator (PauliwordOp): Operator projected over fixed qubit positions stabilized by single Pauli operators.
-
+            ref_state (np.array): Reference State. By default, it is set to None.
+            sector (np.array): Sector. By default it is set to none. If no sector is provided then a reference state must be given instead.
         Returns:
             Reduced operator corresponding to the given stabilizers and eigenvalues.
         """

--- a/symmer/projection/base.py
+++ b/symmer/projection/base.py
@@ -23,7 +23,7 @@ class S3_projection:
         to implement unitary partitioning where necessary. 
 
     Attributes:
-        rotated_flag (bool): If true, operator will be rotated. By default, it is set to 'false'.
+        rotated_flag (bool): If true, the operator is rotated. By default it is set to 'false'.
     """
     rotated_flag = False
 
@@ -50,7 +50,10 @@ class S3_projection:
         stabilized by single Pauli operators (obtained via Clifford operations).
 
         Args:
-            operator (PauliwordOp): Operator which has to be projected over fixed qubit positions stabilized by single Pauli operators.
+            operator (PauliwordOp): Operator to be projected over fixed qubit positions stabilized by single Pauli operators.
+
+        Returns:
+            PauliwordOp representing the projection of input operator.
         """
         assert(operator.n_qubits == self.stabilizers.n_qubits), 'The input operator does not have the same number of qubits as the stabilizers'
         assert(self.rotated_flag), 'The operator has not been rotated - intended for use with perform_projection method'
@@ -91,7 +94,13 @@ class S3_projection:
         
         insert_rotation allows one to include supplementary Pauli rotations
         to be performed prior to the stabilizer rotations, for example 
-        unitary partitioning in CS-VQE
+        unitary partitioning in CS-VQE.
+
+        Args: 
+            operator (PauliwordOp): Operator projected over fixed qubit positions stabilized by single Pauli operators.
+
+        Returns:
+            Reduced operator corresponding to the given stabilizers and eigenvalues.
         """
         if sector is None and ref_state is not None:
             #assert(ref_state is not None), 'If no sector is provided then a reference state must be given instead'
@@ -114,7 +123,14 @@ class S3_projection:
         return self._perform_projection(operator=op_rotated)
     
     def project_state(self, state: QuantumState) -> QuantumState:
-        """ Project a state into the stabilizer subspace
+        """ 
+        Project a state into the stabilizer subspace.
+
+        Args:
+            state (QuantumState): The state which has to be projected into the stabilizer subspace.
+
+        Returns: 
+            Projection of input QuantumState into the stabilizer subspace.
         """
         transformation_list = []
         # Hadamards where rotated onto Pauli X operators

--- a/symmer/projection/base.py
+++ b/symmer/projection/base.py
@@ -23,7 +23,7 @@ class S3_projection:
         to implement unitary partitioning where necessary. 
 
     Attributes:
-        rotated_flag (bool): If true, the operator is rotated. By default it is set to 'false'.
+        rotated_flag (bool): If True, the operator is rotated. By default it is set to 'False'.
     """
     rotated_flag = False
 

--- a/symmer/projection/contextual_subspace.py
+++ b/symmer/projection/contextual_subspace.py
@@ -8,7 +8,8 @@ from symmer.evolution import trotter
 from typing import List, Union, Optional
 
 class ContextualSubspace(S3_projection):
-    """ Class for performing contextual subspace methods as per https://quantum-journal.org/papers/q-2021-05-14-456/.
+    """ 
+    Class for performing contextual subspace methods as per https://quantum-journal.org/papers/q-2021-05-14-456/.
     Reduces the number of qubits in the problem while aiming to control the systematic error incurred along the way.
 
     This class handles the following:
@@ -35,6 +36,15 @@ class ContextualSubspace(S3_projection):
             noncontextual_expansion_order: int = 1
         ):
         """
+        Args: 
+            operator(PauliwordOp): Operator one wishes to enforce as stabilizers over the contextual subspace.
+            noncontextual_strategy (str): Non-Contextual Strategy to be applied. Its default value is'diag'.
+            noncontextual_solver (str): Non-contextual solver to be applied. Its default value is'brute_force'.
+            num_anneals (int): 
+            unitary_partitioning_method (str): Unitary Partitioning Method to be applied. Its default value is'seq_rot'.
+            reference_state (QuantumState): 
+            noncontextual_operator (NoncontextualOp): Non-contextual Operator.
+            noncontextual_expansion_order (int): Non-contextual Expansion Order. Its default value is 1.       
         """
         # noncontextual startegy will have the form x_y, where x is the actual strategy
         # and y is some supplementary method indicating a sorting key such as magnitude
@@ -60,7 +70,11 @@ class ContextualSubspace(S3_projection):
         self._noncontextual_update()
 
     def manual_stabilizers(self, S: Union[List[str], IndependentOp]) -> None:
-        """ Specify a set of operators to enforce manually
+        """ 
+        Specify a set of operators to enforce manually.
+
+        Args:
+            S (IndependentOp): Set of Stablizers
         """
         if isinstance(S, list):
             S = IndependentOp.from_list(S)
@@ -79,7 +93,15 @@ class ContextualSubspace(S3_projection):
             HF_array: np.array = None,
             use_X_only: bool = True
         ) -> None:
-        """ Update the stabilizers that will be used for the subspace projection
+        """ 
+        Update the stabilizers that will be used for the subspace projection.
+
+        Args:
+            n_qubits (int): Number of Qubits
+            strategy (str): Strategy to be applied. It's default value is 'aux_preserving'.
+            aux_operator (PauliwordOp): Auxiliary operator.
+            HF_array (np.array): Hartree-Fock state
+            use_X_only (bool): Default value is 'true'.
         """
         assert(n_qubits<=self.operator.n_qubits), (
             'Cannot define a contextual subspace larger than the base Hamiltonian'
@@ -114,7 +136,8 @@ class ContextualSubspace(S3_projection):
             self._prepare_stabilizers()
 
     def _noncontextual_update(self):
-        """ To be executed each time the noncontextual operator is updated.
+        """ 
+        To be executed each time the noncontextual operator is updated.
         """
         if self.noncontextual_operator is not None:
             self.noncontextual_operator.up_method = self.unitary_partitioning_method
@@ -134,8 +157,17 @@ class ContextualSubspace(S3_projection):
             aux_operator: PauliwordOp,
             use_X_only: bool = True
         ) -> IndependentOp:
-        """ Choose stabilizers that preserve some auxiliary operator.
+        """
+        Choose stabilizers that preserve some auxiliary operator.
         This could be an Ansatz operator such as UCCSD, for example.
+
+        Args:
+            n_qubits (int): Number of Qubits
+            aux_operator (PauliwordOp): Auxiliary operator.
+            use_X_only (bool): Default value is 'true'.
+
+        Returns:
+            S (IndependentOp):  Stablizer that preserves the passed auxiliary operator.
         """
         if aux_operator is None:
             if self.nc_strategy == 'StabilizeFirst':
@@ -154,8 +186,18 @@ class ContextualSubspace(S3_projection):
             weighting_operator: PauliwordOp = None,
             use_X_only:bool = True
         ) -> IndependentOp:
-        """ Bias the Hamiltonian with respect to the HOMO-LUMO gap 
+        """ 
+        Bias the Hamiltonian with respect to the HOMO-LUMO gap 
         and preserve terms in the resulting operator as above.
+
+        Args:
+            n_qubits (int): Number of Qubits
+            HF_array (np.array): Hartree-Fock state
+            weighting_operator (PauliwordOp): Weighting Operator
+            use_X_only (bool): Default value is 'true'.
+
+        Returns:
+            S (IndependentOp): Set of Stablizers
         """
         assert(HF_array is not None), 'Must supply the Hartree-Fock state for this strategy'
         
@@ -174,7 +216,14 @@ class ContextualSubspace(S3_projection):
     def _random_stabilizers(self, 
             n_qubits: int
         )  -> IndependentOp:
-        """ Generate a random set of stabilizers
+        """ 
+        Generate a random set of stabilizers.
+
+        Args:
+            n_qubits (int): Number of Qubits
+        
+        Returns: 
+            S (IndependentOp): Random set of Stablizers
         """
         # TODO better approach that does not rely on this *potentially infinite* while loop!
         found_stabilizers=False
@@ -194,9 +243,9 @@ class ContextualSubspace(S3_projection):
         return S
 
     def _prepare_stabilizers(self) -> None:
-        """ Prepare the chosen stabilizers for projection into the contextual subspace.
-        This includes eigenvalue assignment (obtained from the solution of the noncontextual Hamiltonian),
-        and application of unitary partitioning if enforcing a clique element.
+        """ 
+        Prepare the chosen stabilizers for projection into the contextual subspace.
+        This includes eigenvalue assignment (obtained from the solution of the noncontextual Hamiltonian), and application of unitary partitioning if enforcing a clique element.
         """
         self.S3_initialized = False
         #the StabilizeFirst strategy differs from the others in that the noncontextual
@@ -245,8 +294,15 @@ class ContextualSubspace(S3_projection):
             self.perform_unitary_partitioning = False
 
     def project_onto_subspace(self, operator_to_project:PauliwordOp=None) -> PauliwordOp:
-        """ Projects with respect to the current stabilizers; these are 
+        """ 
+        Projects with respect to the current stabilizers; these are 
         updated using the ContextualSubspace.update_stabilizers method.
+
+        Args:
+            operator_to_project (PauliwordOp): Operator to be projected.
+
+        Returns:
+            Projection of operator passed.
         """
         # if not supplied with an alternative operator for projection, use the internal operator 
         if operator_to_project is None:
@@ -285,7 +341,14 @@ class ContextualSubspace(S3_projection):
     def project_state_onto_subspace(self, 
             state_to_project: QuantumState = None
         ) -> QuantumState:
-        """ Project a QuantumState into the contextual subspace
+        """ 
+        Project a QuantumState into the contextual subspace
+
+        Args:
+            state_to_project (QuantumState): Quantum State to be projected into the contextual subspace
+
+        Reutrns:
+            Projection of passed Quantum State into the contextual subspace.
         """
         # if there are no stabilizers, return the input QuantumState
         if self.stabilizers is None:

--- a/symmer/projection/contextual_subspace.py
+++ b/symmer/projection/contextual_subspace.py
@@ -101,7 +101,7 @@ class ContextualSubspace(S3_projection):
             strategy (str): Strategy to be applied. It's default value is 'aux_preserving'.
             aux_operator (PauliwordOp): Auxiliary operator. By default, it is set to None.
             HF_array (np.array): Hartree-Fock state. By default, it is set to None.
-            use_X_only (bool): Default value is 'true'.
+            use_X_only (bool): Default value is 'True'.
         """
         assert(n_qubits<=self.operator.n_qubits), (
             'Cannot define a contextual subspace larger than the base Hamiltonian'
@@ -164,7 +164,7 @@ class ContextualSubspace(S3_projection):
         Args:
             n_qubits (int): Number of Qubits
             aux_operator (PauliwordOp): Auxiliary operator.
-            use_X_only (bool): Default value is 'true'.
+            use_X_only (bool): Default value is 'True'.
 
         Returns:
             S (IndependentOp):  Stablizer that preserves the passed auxiliary operator.
@@ -194,7 +194,7 @@ class ContextualSubspace(S3_projection):
             n_qubits (int): Number of Qubits
             HF_array (np.array): Hartree-Fock state
             weighting_operator (PauliwordOp): Weighting Operator. By default, it is set to None.
-            use_X_only (bool): Default value is 'true'.
+            use_X_only (bool): Default value is 'True'.
 
         Returns:
             S (IndependentOp): Set of Stablizers

--- a/symmer/projection/contextual_subspace.py
+++ b/symmer/projection/contextual_subspace.py
@@ -40,7 +40,7 @@ class ContextualSubspace(S3_projection):
             operator(PauliwordOp): Operator one wishes to enforce as stabilizers over the contextual subspace.
             noncontextual_strategy (str): Non-Contextual Strategy to be applied. Its default value is'diag'.
             noncontextual_solver (str): Non-contextual solver to be applied. Its default value is'brute_force'.
-            num_anneals (int): By default, it is set to 1000.
+            num_anneals (int): Number of simulated anneals to do. By default, it is set to 1000.
             unitary_partitioning_method (str): Unitary Partitioning Method to be applied. Its default value is'seq_rot'.
             reference_state (QuantumState): Reference State. By default, it is set to None.
             noncontextual_operator (NoncontextualOp): Non-contextual Operator. By default, it is set to None.

--- a/symmer/projection/contextual_subspace.py
+++ b/symmer/projection/contextual_subspace.py
@@ -40,10 +40,10 @@ class ContextualSubspace(S3_projection):
             operator(PauliwordOp): Operator one wishes to enforce as stabilizers over the contextual subspace.
             noncontextual_strategy (str): Non-Contextual Strategy to be applied. Its default value is'diag'.
             noncontextual_solver (str): Non-contextual solver to be applied. Its default value is'brute_force'.
-            num_anneals (int): 
+            num_anneals (int): By default, it is set to 1000.
             unitary_partitioning_method (str): Unitary Partitioning Method to be applied. Its default value is'seq_rot'.
-            reference_state (QuantumState): 
-            noncontextual_operator (NoncontextualOp): Non-contextual Operator.
+            reference_state (QuantumState): Reference State. By default, it is set to None.
+            noncontextual_operator (NoncontextualOp): Non-contextual Operator. By default, it is set to None.
             noncontextual_expansion_order (int): Non-contextual Expansion Order. Its default value is 1.       
         """
         # noncontextual startegy will have the form x_y, where x is the actual strategy
@@ -99,8 +99,8 @@ class ContextualSubspace(S3_projection):
         Args:
             n_qubits (int): Number of Qubits
             strategy (str): Strategy to be applied. It's default value is 'aux_preserving'.
-            aux_operator (PauliwordOp): Auxiliary operator.
-            HF_array (np.array): Hartree-Fock state
+            aux_operator (PauliwordOp): Auxiliary operator. By default, it is set to None.
+            HF_array (np.array): Hartree-Fock state. By default, it is set to None.
             use_X_only (bool): Default value is 'true'.
         """
         assert(n_qubits<=self.operator.n_qubits), (
@@ -193,7 +193,7 @@ class ContextualSubspace(S3_projection):
         Args:
             n_qubits (int): Number of Qubits
             HF_array (np.array): Hartree-Fock state
-            weighting_operator (PauliwordOp): Weighting Operator
+            weighting_operator (PauliwordOp): Weighting Operator. By default, it is set to None.
             use_X_only (bool): Default value is 'true'.
 
         Returns:
@@ -299,7 +299,7 @@ class ContextualSubspace(S3_projection):
         updated using the ContextualSubspace.update_stabilizers method.
 
         Args:
-            operator_to_project (PauliwordOp): Operator to be projected.
+            operator_to_project (PauliwordOp): Operator to be projected. By default, it is set to None.
 
         Returns:
             Projection of operator passed.
@@ -345,7 +345,7 @@ class ContextualSubspace(S3_projection):
         Project a QuantumState into the contextual subspace
 
         Args:
-            state_to_project (QuantumState): Quantum State to be projected into the contextual subspace
+            state_to_project (QuantumState): Quantum State to be projected into the contextual subspace. By default, it is set to None.
 
         Reutrns:
             Projection of passed Quantum State into the contextual subspace.

--- a/symmer/projection/qubit_subspace_manager.py
+++ b/symmer/projection/qubit_subspace_manager.py
@@ -27,7 +27,7 @@ class QubitSubspaceManager:
     Hamiltonian is sufficiently small, or using a DMRG calculation.
 
     Attributes:
-        _projection_ready (bool): If true, Hamiltonian is ready for projection. By default, it is set to false.
+        _projection_ready (bool): If True, Hamiltonian is ready for projection. By default, it is set to False.
     """
 
     _projection_ready = False
@@ -42,8 +42,8 @@ class QubitSubspaceManager:
         Args:
             hamiltonian (PauliwordOp): Hamiltonian which is to be projected.
             ref_state (QuantumState): Reference State. If no reference state is provided, then try to generate one. By default, it is set to None.
-            run_qubit_tapering (bool): If true, Qubit Tapering is performed. By default, it is set to true. 
-            run_contextual_subspace (bool): If true, Contextual Subspace Method is used to solve the problem. By default, it is set to true.
+            run_qubit_tapering (bool): If True, Qubit Tapering is performed. By default, it is set to True. 
+            run_contextual_subspace (bool): If True, Contextual Subspace Method is used to solve the problem. By default, it is set to True.
         """
         self.hamiltonian = hamiltonian
         self.ref_state = self.prepare_ref_state(ref_state)

--- a/symmer/projection/qubit_subspace_manager.py
+++ b/symmer/projection/qubit_subspace_manager.py
@@ -7,7 +7,8 @@ import numpy as np
 import warnings
 
 class QubitSubspaceManager:
-    """ Class for automating the following qubit subspace techqniques:
+    """ 
+    Class for automating the following qubit subspace techqniques:
 
     *** QubitTapering ***
     - Maps each Z2-symmetry onto distinct qubits and projects over them
@@ -24,6 +25,9 @@ class QubitSubspaceManager:
     such as Hartree-Fock. Otherwise, Symmer will try to identify an
     alternative refernce, either via direct diagonalization  if the 
     Hamiltonian is sufficiently small, or using a DMRG calculation.
+
+    Attributes:
+        _projection_ready (bool): If true, Hamiltonian is ready for projection. By default, it is set to false.
     """
 
     _projection_ready = False
@@ -35,6 +39,11 @@ class QubitSubspaceManager:
             run_contextual_subspace: bool = True
         ) -> None:
         """
+        Args:
+            hamiltonian (PauliwordOp): Hamiltonian which is to be projected.
+            ref_state (QuantumState): Reference State. If no reference state is provided, then try to generate one. By default, it is set to None.
+            run_qubit_tapering (bool): If true, Qubit Tapering is performed. By default, it is set to true. 
+            run_contextual_subspace (bool): If true, Contextual Subspace Method is used to solve the problem. By default, it is set to true.
         """
         self.hamiltonian = hamiltonian
         self.ref_state = self.prepare_ref_state(ref_state)
@@ -43,10 +52,17 @@ class QubitSubspaceManager:
         self.build_subspace_objects()
         
     def prepare_ref_state(self, ref_state=None) -> QuantumState:
-        """ If no reference state is provided, then try to generate one.
+        """ 
+        If no reference state is provided, then try to generate one.
         If the Hamiltonian contains fewer than 12 qubits, we will diagonalise
         and select the true ground state. Otherwise, a cheap DMRG calculation
         will be performed to generate an approximate ground state.
+
+        Args: 
+            ref_state (QuantumState): Reference State. If no reference state is provided, then try to generate one. By default, it is set to None.
+
+        Returns:
+            ref_state (QuantumState): Generated Reference State.
         """
         if ref_state is not None:
             if isinstance(ref_state, list):
@@ -70,7 +86,8 @@ class QubitSubspaceManager:
         return ref_state.cleanup(zero_threshold=1e-4).normalize
 
     def build_subspace_objects(self) -> None:
-        """ Initialize the relevant qubit subspace classes.
+        """ 
+        Initialize the relevant qubit subspace classes.
         """
         if self.run_qubit_tapering:
             self.QT             = QubitTapering(operator=self.hamiltonian)
@@ -93,8 +110,16 @@ class QubitSubspaceManager:
     def get_reduced_hamiltonian(self, 
             n_qubits:int=None, aux_operator:PauliwordOp=None
         ) -> PauliwordOp:
-        """ Project the Hamiltonian in line with the desired qubit subspace techqniques
+        """ 
+        Project the Hamiltonian in line with the desired qubit subspace techqniques
         and, in the case of ContextualSubspace, the desired number of qubits.
+
+        Args:
+            n_qubits (int): Number of Qubits. By default, it is set to None.
+            aux_operator (PauliwordOp): Auxiliary operator. By default, it is set to None.
+
+        Returns:
+            operator_out (PauliwordOp): Projection of Hamiltonian.
         """
         self._projection_ready = True
         self._n_qubits = n_qubits
@@ -139,7 +164,14 @@ class QubitSubspaceManager:
         return operator_out
         
     def project_auxiliary_operator(self, operator: PauliwordOp) -> PauliwordOp:
-        """ Project additional operators consistently with respect to the Hamiltonian.
+        """ 
+        Project additional operators consistently with respect to the Hamiltonian.
+
+        Args:
+            operator (PauliwordOp): Additional operator which has to be projected consistently with respect to the Hamiltonian.
+
+        Returns:
+            operator (PauliwordOp): Projection of additional operator.
         """
         assert self._projection_ready, 'Have not yet projected the Hamiltonian into the contextual subspace'
 
@@ -154,7 +186,14 @@ class QubitSubspaceManager:
         return operator
     
     def project_auxiliary_state(self, state: QuantumState) -> QuantumState:
-        """ Project additional operators consistently with respect to the Hamiltonian.
+        """ 
+        Project additional operators consistently with respect to the Hamiltonian.
+
+        Args:
+            operator (QuantumState): Quantum State which has to be projected consistently with respect to the Hamiltonian.
+        
+        Returns:
+            operator (PauliwordOp): Projection of Quantum State.
         """
         assert self._projection_ready, 'Have not yet projected the Hamiltonian into the contextual subspace'
 

--- a/symmer/projection/qubit_subspace_manager.py
+++ b/symmer/projection/qubit_subspace_manager.py
@@ -187,7 +187,7 @@ class QubitSubspaceManager:
     
     def project_auxiliary_state(self, state: QuantumState) -> QuantumState:
         """ 
-        Project additional operators consistently with respect to the Hamiltonian.
+        Project quantum state consistently with respect to the Hamiltonian.
 
         Args:
             operator (QuantumState): Quantum State which has to be projected consistently with respect to the Hamiltonian.

--- a/symmer/projection/qubit_tapering.py
+++ b/symmer/projection/qubit_tapering.py
@@ -7,7 +7,8 @@ from symmer.projection import S3_projection
 from symmer.operators import PauliwordOp, IndependentOp, QuantumState
 
 class QubitTapering(S3_projection):
-    """ Class for performing qubit tapering as per https://arxiv.org/abs/1701.08213.
+    """ 
+    Class for performing qubit tapering as per https://arxiv.org/abs/1701.08213.
     Reduces the number of qubits in the problem whilst preserving its energy spectrum by:
 
     1. identifying a symmetry of the Hamiltonian,
@@ -17,15 +18,19 @@ class QubitTapering(S3_projection):
     5. fixing the +/-1 eigenvalues
 
     Steps 1-2 are handled in this class whereas we defer to the parent S3_projection for 3-5.
-
     """
     def __init__(self,
             operator: PauliwordOp, 
             target_sqp: str = 'X'
         ) -> None:
-        """ Input the PauliwordOp we wish to taper.
+        """ 
+        Input the PauliwordOp we wish to taper.
         There is freedom over the choice of single-qubit Pauli operator we wish to rotate onto, 
         however this is set to X by default (in line with the original tapering paper).
+
+        Args: 
+            operator (PauliwordOp): The Operator you want to tapper.
+            target_sqp (str): The single-qubit Pauli operator we wish to rotate onto. By default, it is set to 'X'.
         """
         self.operator = operator
         self.target_sqp = target_sqp
@@ -34,7 +39,11 @@ class QubitTapering(S3_projection):
         
     @cached_property
     def symmetry_generators(self) -> IndependentOp:
-        """ Find an independent basis for the input operator symmetry
+        """ 
+        Find an independent basis for the input operator symmetry.
+
+        Returns:
+            stabilizers (IndependentOp): Set of stablizers.
         """
         stabilizers = IndependentOp.symmetry_generators(self.operator)
         stabilizers.target_sqp = self.target_sqp
@@ -45,7 +54,8 @@ class QubitTapering(S3_projection):
             sector: Union[List[int], np.array]=None,
             aux_operator: PauliwordOp = None
         ) -> PauliwordOp:
-        """ Finally, once the symmetry generators and sector have been identified, 
+        """ 
+        Finally, once the symmetry generators and sector have been identified, 
         we may perform a projection onto the corresponding stabilizer subspace via 
         the parent S3_projection class.
 
@@ -54,6 +64,14 @@ class QubitTapering(S3_projection):
         especially useful when considering an Ansatz defined over the full system that 
         one wishes to restrict to the same stabilizer subspace as the Hamiltonian for 
         use in VQE, for example.
+
+        Args:
+            ref_state (np.array): Reference State. By default, it is set to None.
+            sector (np.array): Sector. By default it is set to none.
+            aux_operator (PauliwordOp): Auxiliary operator. By default, it is set to None.
+
+        Returns:
+            tapered_operator (PauliwordOp): Tappered Operator
         """
         if ref_state is not None:
             if not isinstance(ref_state, QuantumState):

--- a/symmer/utils.py
+++ b/symmer/utils.py
@@ -15,10 +15,22 @@ def exact_gs_energy(
         number_operator=None, 
         n_eigs=6
     ) -> Tuple[float, np.array]:
-    """ Return the ground state energy and corresponding ground statevector for the input operator
+    """ 
+    Return the ground state energy and corresponding ground statevector for the input operator
     
     Specifying a particle number will restrict to eigenvectors |ψ> such that <ψ|N_op|ψ> = n_particles
     where N_op is the given number operator.
+
+    Args:
+        sparse_matrix (csr_matrix): The sparse matrix for which we want to compute the eigenvalues and eigenvectors.
+        initial_guess (array): The initial guess for the eigenvectors.
+        n_particles (int):  Particle number to restrict eigenvectors |ψ> such that <ψ|N_op|ψ> = n_particles where N_op is the given number operator.
+        number_operator (array): Number Operator to restrict eigenvectors |ψ> such that <ψ|N_op|ψ> = n_particles.
+        n_eigs (int): The number of eigenvalues and eigenvectors to compute.
+
+    Returns:
+        evl(float): The ground state energy for the input operator
+        QState(QuantumState): Ground statevector for the input operator corresponding to evl.
     """
     if number_operator is None:
         # if no number operator then need not compute any further eigenvalues
@@ -62,10 +74,19 @@ def exact_gs_energy(
 
 
 def random_anitcomm_2n_1_PauliwordOp(n_qubits, complex_coeff=False, apply_clifford=True):
-    """ Generate a anticommuting PauliOperator of size 2n+1 on n qubits (max possible size)
-        with normally distributed coefficients. Generates in structured way then uses Clifford rotation (default)
-        to try and make more random (can stop this to allow FAST build, but inherenet structure
-         will be present as operator is formed in specific way!)
+    """ 
+    Generate a anticommuting PauliOperator of size 2n+1 on n qubits (max possible size)
+    with normally distributed coefficients. Generates in structured way then uses Clifford rotation (default)
+    to try and make more random (can stop this to allow FAST build, but inherenet structure
+    will be present as operator is formed in specific way!)
+
+    Args:
+        n_qubits (int): Number of Qubits
+        complex_coeff (bool): Boolean representing whether if we want complex coefficents or not.
+        apply_clifford (bool): Boolean representing whether we want to apply clifford rotations to get rid of structure or not.
+
+    Returns:
+        P_anticomm (csr_matrix): Anticommuting PauliOperator of size 2n+1 on n qubits with normally distributed coefficients.
     """
     # base = 'X' * n_qubits
     # I_term = 'I' * n_qubits
@@ -117,13 +138,27 @@ def random_anitcomm_2n_1_PauliwordOp(n_qubits, complex_coeff=False, apply_cliffo
 
 
 def tensor_list(factor_list:List[PauliwordOp]) -> PauliwordOp:
-    """ Given a list of PauliwordOps, recursively tensor from the right
+    """ 
+    Given a list of PauliwordOps, recursively tensor from the right
+    
+    Args:
+        factor_list (list): list of PauliwordOps
+    
+    Returns: 
+        Tensor Product of items in factor_list from the right 
     """
     return reduce(lambda x,y:x.tensor(y), factor_list)
 
 
 def product_list(product_list:List[PauliwordOp]) -> PauliwordOp:
-    """ Given a list of PauliwordOps, recursively take product from the right
+    """ 
+    Given a list of PauliwordOps, recursively take product from the right
+
+    Args:
+        product_list (list): list of PauliwordOps
+
+    Returns:
+        Product of items in product_list from the right 
     """
     return reduce(lambda x,y:x*y, product_list)
 


### PR DESCRIPTION
The Symmer codebase is completely documented, but in an unofficial style. I am formatting the documentation into the [Google style](https://google.github.io/styleguide/pyguide.html). Creating this PR for issue #139. The Formatting is not completed yet, but creating this PR to keep in loop with maintainer.