### PR TITLE
Symmer import speed up

### DIFF
--- a/symmer/operators/base.py
+++ b/symmer/operators/base.py
@@ -1,7 +1,7 @@
 import os
 import quimb
 from symmer.operators.utils import *
-import ray
+from ray import put, get, remote
 import numpy as np
 import pandas as pd
 import networkx as nx
@@ -829,8 +829,8 @@ class PauliwordOp:
         """
         if self.n_terms > 1:
             # parallelize if number of terms greater than one
-            psi_ray_store = ray.put(psi)
-            expvals = np.array(ray.get(
+            psi_ray_store = put(psi)
+            expvals = np.array(get(
                 [single_term_expval.remote(P, psi_ray_store) for P in self]))
         else:
             expvals = np.array(single_term_expval(self, psi))
@@ -2399,7 +2399,7 @@ def get_ij_operator(i:int, j:int, n_qubits:int,
     else:
         return ij_symp_matrix, coeffs
 
-@ray.remote(num_cpus=os.cpu_count(),
+@remote(num_cpus=os.cpu_count(),
             runtime_env={
                 "env_vars": {
                     "NUMBA_NUM_THREADS": os.getenv("NUMBA_NUM_THREADS"),

--- a/symmer/operators/independent_op.py
+++ b/symmer/operators/independent_op.py
@@ -4,7 +4,7 @@ import warnings
 import multiprocessing as mp
 from symmer.operators.utils import _rref_binary, _cref_binary, check_independent
 from symmer.operators import PauliwordOp, QuantumState, symplectic_to_string, single_term_expval
-import ray
+from ray import put, get, remote
 
 class IndependentOp(PauliwordOp):
     """ 
@@ -296,8 +296,8 @@ class IndependentOp(PauliwordOp):
         #     self.coeff_vec = np.array(
         #         list(pool.starmap(assign_value, [(S, ref_state, threshold) for S in self]))
         #     )
-        ref_state_ray_store = ray.put(ref_state)
-        self.coeff_vec = np.array(ray.get(
+        ref_state_ray_store = put(ref_state)
+        self.coeff_vec = np.array(get(
                         [single_term_expval.remote(S, ref_state_ray_store) for S in self]))
         # set anything below threshold to be zero
         self.coeff_vec[np.abs(self.coeff_vec)<threshold] = 0

--- a/symmer/utils.py
+++ b/symmer/utils.py
@@ -8,7 +8,7 @@ from scipy.sparse import csr_matrix
 from scipy.sparse import kron as sparse_kron
 from symmer.operators.utils import _rref_binary
 import multiprocessing as mp
-import ray
+from ray import put, get, remote
 import os
 # from psutil import cpu_count
 
@@ -270,20 +270,20 @@ def get_sparse_matrix_large_pauliwordop(P_op: PauliwordOp) -> csr_matrix:
         n_chunks = os.cpu_count()
         if (n_chunks<=1) or (P_op.n_terms<=1):
             # no multiprocessing possible
-            mat = ray.get(_get_sparse_matrix_large_pauliwordop.remote(P_op))
+            mat = get(_get_sparse_matrix_large_pauliwordop.remote(P_op))
         else:
             # plus one below due to indexing (actual number of chunks ignores this value)
             n_chunks += 1
             P_op_chunks_inds = np.rint(np.linspace(0, P_op.n_terms, min(n_chunks, P_op.n_terms+1))).astype(set).astype(int)
             P_op_chunks = [P_op[P_op_chunks_inds[ind_i]: P_op_chunks_inds[ind_i + 1]] for ind_i, _ in
                            enumerate(P_op_chunks_inds[1:])]
-            tracker = np.array(ray.get(
+            tracker = np.array(get(
                 [_get_sparse_matrix_large_pauliwordop.remote(op) for op in P_op_chunks]))
             mat = reduce(lambda x, y: x + y, tracker)
 
     return mat
 
-@ray.remote(num_cpus=os.cpu_count(),
+@remote(num_cpus=os.cpu_count(),
             runtime_env={
                 "env_vars": {
                     "NUMBA_NUM_THREADS": os.getenv("NUMBA_NUM_THREADS"),


### PR DESCRIPTION
Import was taking way too long

![Screenshot from 2023-11-02 13-58-46](https://github.com/UCL-CCS/symmer/assets/55510238/6c5bb4b2-6558-4871-8ffd-12cac4a61049)

Quick check suggested that the biggest dependency was `ray`.

Each file only uses `put, get, remote` so import changed to specifically these.

Import is much faster as a result.

![Screenshot from 2023-11-02 13-59-27](https://github.com/UCL-CCS/symmer/assets/55510238/1852883f-f97e-40a5-a881-b24481965db0)

